### PR TITLE
fix make test-dependencies by only perform 'mv' if kubebuilder doesn't t exist already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test:
 
 test-dependencies:
 	curl -L https://go.kubebuilder.io/dl/2.3.0/$(GOOS)/$(GOARCH) | tar -xz -C /tmp/
-	sudo mv /tmp/kubebuilder_2.3.0_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
+	sudo mv -n /tmp/kubebuilder_2.3.0_$(GOOS)_$(GOARCH) /usr/local/kubebuilder
 	export PATH=$PATH:/usr/local/kubebuilder/bin
 
 ############################################################


### PR DESCRIPTION
Addresses open-cluster-management-io/community#58

Signed-off-by: Mike Ng <ming@redhat.com>