### PR TITLE
Update to `latest` tag for images

### DIFF
--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -35,4 +35,4 @@ jobs:
       - name: push
         run: |
           echo ${{ secrets.DOCKER_PASSWORD }} | docker login quay.io --username ${{ secrets.DOCKER_USER }} --password-stdin
-          docker push quay.io/open-cluster-management/governance-policy-propagator:edge
+          docker push quay.io/open-cluster-management/governance-policy-propagator:latest

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 REGISTRY ?= quay.io/open-cluster-management
-TAG ?= edge
+TAG ?= latest
 
 # Github host to use for checking the source tree;
 # Override this variable ue with your own value if you're working on forked repo.

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: governance-policy-propagator
       containers:
         - name: governance-policy-propagator
-          image: quay.io/open-cluster-management/governance-policy-propagator:edge
+          image: quay.io/open-cluster-management/governance-policy-propagator:latest
           command:
             - governance-policy-propagator
           args:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -271,7 +271,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
-        image: quay.io/open-cluster-management/governance-policy-propagator:edge
+        image: quay.io/open-cluster-management/governance-policy-propagator:latest
         imagePullPolicy: Always
         name: governance-policy-propagator
         ports:


### PR DESCRIPTION
Originally `edge` was to distinguish from midstream, but this is no longer necessary.
