### PR TITLE
Fix text/template so that it doesn't confuse the action for a delimiter

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,8 +5,17 @@ FROM golang:1.17 AS builder
 
 ENV COMPONENT=governance-policy-propagator
 ENV REPO_PATH=/go/src/github.com/open-cluster-management/${COMPONENT}
+# Account for Prow replacing the base image to be UBI based
+RUN if [ -x "$(command -v dnf)" ] ; then \
+        dnf install -y patch; \
+    else \
+        apt update && apt install -y patch; \
+    fi
 WORKDIR ${REPO_PATH}
 COPY . .
+# TODO: Remove this patch when updating to Go 1.19
+# https://go-review.googlesource.com/c/go/+/398475
+RUN patch -p1 /usr/local/go/src/text/template/parse/lex.go build/template-delimiter.patch
 RUN make build
 
 # Stage 2: Copy the binaries from the image builder to the base image

--- a/build/template-delimiter.patch
+++ b/build/template-delimiter.patch
@@ -1,0 +1,36 @@
+diff --git a/src/text/template/parse/lex.go b/src/text/template/parse/lex.go
+index 40d0411..078f714 100644
+--- a/src/text/template/parse/lex.go
++++ b/src/text/template/parse/lex.go
+@@ -541,13 +541,25 @@
+ 	case eof, '.', ',', '|', ':', ')', '(':
+ 		return true
+ 	}
+-	// Does r start the delimiter? This can be ambiguous (with delim=="//", $x/2 will
+-	// succeed but should fail) but only in extremely rare cases caused by willfully
+-	// bad choice of delimiter.
+-	if rd, _ := utf8.DecodeRuneInString(l.rightDelim); rd == r {
+-		return true
++	// Are we at a right delimiter? TODO: This is harder than it should be
++	// because lookahead is only one rune.
++	rightDelim := l.rightDelim
++	defer func(pos Pos, line int) {
++		l.pos = pos
++		l.line = line
++	}(l.pos, l.line)
++	for len(rightDelim) > 0 {
++		rNext := l.next()
++		if rNext == eof {
++			return false
++		}
++		rDelim, size := utf8.DecodeRuneInString(rightDelim)
++		if rNext != rDelim {
++			return false
++		}
++		rightDelim = rightDelim[size:]
+ 	}
+-	return false
++	return true
+ }
+ 
+ // lexChar scans a character constant. The initial quote is already

--- a/deploy/crds/external/tower.ansible.com_joblaunch_crd.yaml
+++ b/deploy/crds/external/tower.ansible.com_joblaunch_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ansiblejobs.tower.ansible.com
@@ -10,37 +10,45 @@ spec:
     plural: ansiblejobs
     singular: ansiblejob
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Schema validation for the Tower Job Launch CRD
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            extra_vars:
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            inventory:
-              type: string
-            job_template_name:
-              type: string
-            tower_auth_secret:
-              type: string
-          required:
-          - tower_auth_secret
-          - job_template_name
-          type: object
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
-  version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AnsibleJob is the Schema for the ansiblejobs API
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                extra_vars:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                inventory:
+                  type: string
+                job_template_name:
+                  type: string
+                job_ttl:
+                  description: Time to live for k8s job object after the playbook run has finished
+                  type: integer
+                runner_image:
+                  description: Runner image used when running jobs
+                  type: string
+                runner_version:
+                  description: Runner image version used when running jobs
+                  type: string
+                tower_auth_secret:
+                  type: string
+              required:
+                - tower_auth_secret
+                - job_template_name
+              type: object
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
This backports the upstream fix to the text/template library. This is
required so that fields that start with the letter `h` can be accessed
within Hub policy templates.

The second commit is to fix the CI when running against the latest Kubernetes version.

Relates:
https://github.com/stolostron/backlog/issues/21440