### PR TITLE
Change leader election to use the leases resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,13 +187,14 @@ func main() {
 
 	// Set default manager options
 	options := ctrl.Options{
-		Namespace:              namespace,
-		Scheme:                 scheme,
-		MetricsBindAddress:     metricsAddr,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "policy-propagator.open-cluster-management.io",
-		NewCache:               newCacheFunc,
+		Namespace:                  namespace,
+		Scheme:                     scheme,
+		MetricsBindAddress:         metricsAddr,
+		HealthProbeBindAddress:     probeAddr,
+		LeaderElection:             enableLeaderElection,
+		LeaderElectionID:           "policy-propagator.open-cluster-management.io",
+		LeaderElectionResourceLock: "leases",
+		NewCache:                   newCacheFunc,
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)


### PR DESCRIPTION
Switching to using leases instead of configmapsleases for leader
election

Refs:
 - https://github.com/stolostron/backlog/issues/19110

Signed-off-by: Gus Parvin <gparvin@redhat.com>