### PR TITLE
Policyset dependencies

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -49,13 +49,20 @@ func FullNameForPolicy(plc *policiesv1.Policy) string {
 	return plc.GetNamespace() + "." + plc.GetName()
 }
 
-// CompareSpecAndAnnotation compares annotation and spec for given policies
-// true if matches, false if doesn't match
-func CompareSpecAndAnnotation(plc1 *policiesv1.Policy, plc2 *policiesv1.Policy) bool {
-	annotationMatch := equality.Semantic.DeepEqual(plc1.GetAnnotations(), plc2.GetAnnotations())
-	specMatch := equality.Semantic.DeepEqual(plc1.Spec, plc2.Spec)
+// EquivalentReplicatedPolicies compares replicated policies. Returns true if they match.
+func EquivalentReplicatedPolicies(plc1 *policiesv1.Policy, plc2 *policiesv1.Policy) bool {
+	// Compare annotations
+	if !equality.Semantic.DeepEqual(plc1.GetAnnotations(), plc2.GetAnnotations()) {
+		return false
+	}
 
-	return annotationMatch && specMatch
+	// Compare labels
+	if !equality.Semantic.DeepEqual(plc1.GetLabels(), plc2.GetLabels()) {
+		return false
+	}
+
+	// Compare the specs
+	return equality.Semantic.DeepEqual(plc1.Spec, plc2.Spec)
 }
 
 // IsPbForPoicy compares group and kind with policy group and kind for given pb
@@ -200,4 +207,29 @@ func GetNumWorkers(listLength int, concurrencyPerPolicy int) int {
 	}
 
 	return numWorkers
+}
+
+func BuildReplicatedPolicy(root *policiesv1.Policy, decision appsv1.PlacementDecision) *policiesv1.Policy {
+	replicatedName := FullNameForPolicy(root)
+
+	replicated := root.DeepCopy()
+	replicated.SetName(replicatedName)
+	replicated.SetNamespace(decision.ClusterNamespace)
+	replicated.SetResourceVersion("")
+	replicated.SetFinalizers(nil)
+	replicated.SetOwnerReferences(nil)
+
+	labels := root.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	// Extra labels on replicated policies
+	labels[ClusterNameLabel] = decision.ClusterName
+	labels[ClusterNamespaceLabel] = decision.ClusterNamespace
+	labels[RootPolicyLabel] = replicatedName
+
+	replicated.SetLabels(labels)
+
+	return replicated
 }

--- a/controllers/propagator/replication_utils.go
+++ b/controllers/propagator/replication_utils.go
@@ -1,0 +1,60 @@
+package propagator
+
+import (
+	"k8s.io/apimachinery/pkg/api/equality"
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+)
+
+// labelsForRootPolicy returns the labels for given policy
+func labelsForRootPolicy(plc *policiesv1.Policy) map[string]string {
+	return map[string]string{common.RootPolicyLabel: fullNameForPolicy(plc)}
+}
+
+// fullNameForPolicy returns the fully qualified name for given policy
+// full qualified name: ${namespace}.${name}
+func fullNameForPolicy(plc *policiesv1.Policy) string {
+	return plc.GetNamespace() + "." + plc.GetName()
+}
+
+// equivalentReplicatedPolicies compares replicated policies. Returns true if they match.
+func equivalentReplicatedPolicies(plc1 *policiesv1.Policy, plc2 *policiesv1.Policy) bool {
+	// Compare annotations
+	if !equality.Semantic.DeepEqual(plc1.GetAnnotations(), plc2.GetAnnotations()) {
+		return false
+	}
+
+	// Compare labels
+	if !equality.Semantic.DeepEqual(plc1.GetLabels(), plc2.GetLabels()) {
+		return false
+	}
+
+	// Compare the specs
+	return equality.Semantic.DeepEqual(plc1.Spec, plc2.Spec)
+}
+
+func buildReplicatedPolicy(root *policiesv1.Policy, decision appsv1.PlacementDecision) *policiesv1.Policy {
+	replicatedName := fullNameForPolicy(root)
+
+	replicated := root.DeepCopy()
+	replicated.SetName(replicatedName)
+	replicated.SetNamespace(decision.ClusterNamespace)
+	replicated.SetResourceVersion("")
+	replicated.SetFinalizers(nil)
+	replicated.SetOwnerReferences(nil)
+
+	labels := root.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	// Extra labels on replicated policies
+	labels[common.ClusterNameLabel] = decision.ClusterName
+	labels[common.ClusterNamespaceLabel] = decision.ClusterNamespace
+	labels[common.RootPolicyLabel] = replicatedName
+
+	replicated.SetLabels(labels)
+
+	return replicated
+}

--- a/test/e2e/case13_policyset_dependencies_test.go
+++ b/test/e2e/case13_policyset_dependencies_test.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test replacement of policysets in dependencies", Ordered, func() {
+	const (
+		case13PolicyName     string = "case13-test-policy"
+		case13PolicySetName  string = "case13-test-policyset"
+		case13PolicyYaml     string = "../resources/case13_policyset_dependencies/case13-resources.yaml"
+		case13Set2Yaml       string = "../resources/case13_policyset_dependencies/policyset2.yaml"
+		case13Set2updateYaml string = "../resources/case13_policyset_dependencies/policyset2update.yaml"
+	)
+
+	setup := func() {
+		By("Creating the policy, policyset, binding, and rule")
+		utils.Kubectl("apply", "-f", case13PolicyYaml, "-n", testNamespace)
+		rootplc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, case13PolicyName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(rootplc).NotTo(BeNil())
+		plcset := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicySet, case13PolicySetName, testNamespace, true, defaultTimeoutSeconds,
+		)
+		Expect(plcset).NotTo(BeNil())
+
+		By("Patching the rule with a decision of cluster managed1")
+		plr := utils.GetWithTimeout(
+			clientHubDynamic, gvrPlacementRule, case13PolicyName+"-plr", testNamespace, true, defaultTimeoutSeconds,
+		)
+		plr.Object["status"] = utils.GeneratePlrStatus("managed1")
+		_, err := clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+			context.TODO(), plr, metav1.UpdateOptions{},
+		)
+		Expect(err).To(BeNil())
+
+		By("Verifying the replicated policy was created")
+		plc := utils.GetWithTimeout(
+			clientHubDynamic, gvrPolicy, testNamespace+"."+case13PolicyName, "managed1", true, defaultTimeoutSeconds,
+		)
+		Expect(plc).ToNot(BeNil())
+		opt := metav1.ListOptions{
+			LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case13PolicyName,
+		}
+		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
+
+		DeferCleanup(func() {
+			By("Running cleanup")
+			utils.Kubectl("delete", "-f", case13PolicyYaml, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case13Set2Yaml)
+			time.Sleep(5 * time.Second) // this helps everything get cleaned up completely
+		})
+	}
+
+	Describe("testing top-level dependencies", Ordered, func() {
+		const (
+			case13Test1Yaml string = "../resources/case13_policyset_dependencies/test1.yaml"
+			case13Test2Yaml string = "../resources/case13_policyset_dependencies/test2.yaml"
+		)
+
+		BeforeAll(setup)
+
+		getDependencies := func(g Gomega) []string {
+			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy,
+				testNamespace+"."+case13PolicyName, "managed1", true, defaultTimeoutSeconds)
+			deps, found, err := unstructured.NestedSlice(plc.Object, "spec", "dependencies")
+			g.Expect(found).To(BeTrue())
+			g.Expect(err).To(BeNil())
+
+			gotdeps := make([]string, 0)
+
+			for _, d := range deps {
+				dep, ok := d.(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+
+				kind, ok := dep["kind"].(string)
+				g.Expect(ok).To(BeTrue())
+
+				name, ok := dep["name"].(string)
+				g.Expect(ok).To(BeTrue())
+
+				gotdeps = append(gotdeps, kind+":"+name)
+			}
+
+			return gotdeps
+		}
+
+		It("should replace a PolicySet dependency with each policy in the existing set", func() {
+			By("Updating the root policy to have a PolicySet dependency")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test1Yaml, "-n", testNamespace)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of dependencies")
+			Eventually(getDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+			))
+		})
+
+		It("should keep a non-existent PolicySet dependency as-is", func() {
+			By("Updating the root policy to have a non-existent PolicySet dependency")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test2Yaml, "-n", testNamespace)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of dependencies")
+			Eventually(getDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"PolicySet:case13-test-policyset2",
+			))
+		})
+
+		It("should update when the policy set is created", func() {
+			By("Waiting some time, to make sure extra policy reconciles aren't pending")
+			// This helps verify that the the policy is correctly watching the PolicySets,
+			// and isn't just coincidently being re-reconiled for some other reason.
+			time.Sleep(5 * time.Second)
+
+			By("Creating the PolicySet that was non-existent")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of dependencies")
+			Eventually(getDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"Policy:case13-namespace.case13-zubat",
+				"Policy:case13-namespace.case13-psyduck",
+			))
+		})
+
+		It("should update when a dependency policy set is updated", func() {
+			By("Waiting some time, to make sure extra policy reconciles aren't pending")
+			// This helps verify that the the policy is correctly watching the PolicySets,
+			// and isn't just coincidently being re-reconiled for some other reason.
+			time.Sleep(5 * time.Second)
+
+			By("Updating the PolicySet")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of dependencies")
+			Eventually(getDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"Policy:case13-namespace.case13-golbat", // note: these names changed
+				"Policy:case13-namespace.case13-golduck",
+			))
+		})
+	})
+
+	Describe("testing extraDependencies", Ordered, func() {
+		const (
+			case13Test3Yaml string = "../resources/case13_policyset_dependencies/test3.yaml"
+			case13Test4Yaml string = "../resources/case13_policyset_dependencies/test4.yaml"
+		)
+
+		BeforeAll(setup)
+
+		getExtraDependencies := func(g Gomega) []string {
+			plc := utils.GetWithTimeout(clientHubDynamic, gvrPolicy,
+				testNamespace+"."+case13PolicyName, "managed1", true, defaultTimeoutSeconds)
+
+			templates, found, err := unstructured.NestedSlice(plc.Object, "spec", "policy-templates")
+			g.Expect(found).To(BeTrue())
+			g.Expect(err).To(BeNil())
+			g.Expect(templates).To(HaveLen(1))
+
+			template, ok := templates[0].(map[string]interface{})
+			g.Expect(ok).To(BeTrue())
+
+			extraDeps, ok := template["extraDependencies"].([]interface{})
+			g.Expect(ok).To(BeTrue())
+
+			gotdeps := make([]string, 0)
+
+			for _, d := range extraDeps {
+				dep, ok := d.(map[string]interface{})
+				g.Expect(ok).To(BeTrue())
+
+				kind, ok := dep["kind"].(string)
+				g.Expect(ok).To(BeTrue())
+
+				name, ok := dep["name"].(string)
+				g.Expect(ok).To(BeTrue())
+
+				gotdeps = append(gotdeps, kind+":"+name)
+			}
+
+			return gotdeps
+		}
+
+		It("should replace a PolicySet extraDependency with each policy in the existing set", func() {
+			By("Updating the root policy to have a PolicySet extraDependency")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test3Yaml, "-n", testNamespace)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of extraDependencies")
+			Eventually(getExtraDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+			))
+		})
+
+		It("should keep a non-existent PolicySet extraDependency as-is", func() {
+			By("Updating the root policy to have a non-existent PolicySet dependency")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test4Yaml, "-n", testNamespace)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of extraDependencies")
+			Eventually(getExtraDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"PolicySet:case13-test-policyset2",
+			))
+		})
+
+		It("should update when the policy set is created", func() {
+			By("Waiting some time, to make sure extra policy reconciles aren't pending")
+			// This helps verify that the the policy is correctly watching the PolicySets,
+			// and isn't just coincidently being re-reconiled for some other reason.
+			time.Sleep(5 * time.Second)
+
+			By("Creating the PolicySet that was non-existent")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of extraDependencies")
+			Eventually(getExtraDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"Policy:case13-namespace.case13-zubat",
+				"Policy:case13-namespace.case13-psyduck",
+			))
+		})
+
+		It("should update when a dependency policy set is updated", func() {
+			By("Waiting some time, to make sure extra policy reconciles aren't pending")
+			// This helps verify that the the policy is correctly watching the PolicySets,
+			// and isn't just coincidently being re-reconiled for some other reason.
+			time.Sleep(5 * time.Second)
+
+			By("Updating the PolicySet")
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml)
+			Expect(err).To(BeNil())
+
+			By("Checking that the replicated policy has the correct list of dependencies")
+			Eventually(getExtraDependencies, defaultTimeoutSeconds, 1).Should(ConsistOf(
+				"Policy:"+testNamespace+".case13-geodude",
+				"Policy:"+testNamespace+".case13-slowpoke",
+				"Policy:case13-namespace.case13-golbat", // note: these names changed
+				"Policy:case13-namespace.case13-golduck",
+			))
+		})
+	})
+})

--- a/test/resources/case13_policyset_dependencies/case13-resources.yaml
+++ b/test/resources/case13_policyset_dependencies/case13-resources.yaml
@@ -1,0 +1,54 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case13-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case13-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+---
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case13-test-policyset
+spec:
+  policies:
+  - case13-geodude
+  - case13-slowpoke
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case13-test-policy-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case13-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case13-test-policy
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case13-test-policy-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []

--- a/test/resources/case13_policyset_dependencies/policyset2.yaml
+++ b/test/resources/case13_policyset_dependencies/policyset2.yaml
@@ -1,0 +1,14 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: case13-namespace
+---
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case13-test-policyset2
+  namespace: case13-namespace
+spec:
+  policies:
+  - case13-zubat
+  - case13-psyduck

--- a/test/resources/case13_policyset_dependencies/policyset2update.yaml
+++ b/test/resources/case13_policyset_dependencies/policyset2update.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case13-test-policyset2
+  namespace: case13-namespace
+spec:
+  policies:
+  - case13-golbat
+  - case13-golduck

--- a/test/resources/case13_policyset_dependencies/test1.yaml
+++ b/test/resources/case13_policyset_dependencies/test1.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case13-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1beta1
+      kind: PolicySet
+      name: case13-test-policyset
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case13-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io

--- a/test/resources/case13_policyset_dependencies/test2.yaml
+++ b/test/resources/case13_policyset_dependencies/test2.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case13-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  dependencies:
+    - apiVersion: policy.open-cluster-management.io/v1beta1
+      kind: PolicySet
+      name: case13-test-policyset
+      compliance: Compliant
+    - apiVersion: policy.open-cluster-management.io/v1beta1
+      kind: PolicySet
+      name: case13-test-policyset2
+      namespace: case13-namespace
+      compliance: Compliant
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case13-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io

--- a/test/resources/case13_policyset_dependencies/test3.yaml
+++ b/test/resources/case13_policyset_dependencies/test3.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case13-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: PolicySet
+          name: case13-test-policyset
+          compliance: Compliant
+      objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case13-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io

--- a/test/resources/case13_policyset_dependencies/test4.yaml
+++ b/test/resources/case13_policyset_dependencies/test4.yaml
@@ -1,0 +1,30 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case13-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - extraDependencies:
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: PolicySet
+          name: case13-test-policyset
+          compliance: Compliant
+        - apiVersion: policy.open-cluster-management.io/v1beta1
+          kind: PolicySet
+          name: case13-test-policyset2
+          namespace: case13-namespace
+          compliance: Compliant
+      objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case13-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io


### PR DESCRIPTION
Some refactoring to (I think) get things in better shape for the changes, and then this is the main commit message:

Since whether dependencies are satisfied will be calculated on the managed cluster, and since PolicySets are not propagated to managed clusters, in order to work "as expected" by a user, any PolicySet dependencies should be replaced with the Policies that are in that set.

To keep those lists up to date, the root policies need to reconcile whenever the dependent PolicySets are updated, accomplished here with the new dynamic watch library. So now Policies watch items referenced in their templates, as well as relevant PolicySets.

Note: when a PolicySet does not exist, the dependency is not changed - it is expected that the status message from the managed cluster (indicating that the set does not exist) will be sufficient for users to understand the issue.

Refs:
 - https://github.com/stolostron/backlog/issues/26181