### PR TITLE
Fix the dynamic watch cleanup

### DIFF
--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -113,7 +113,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			err := r.cleanUpPolicy(&policiesv1.Policy{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       policiesv1.Kind,
-					APIVersion: policiesv1.SchemeGroupVersion.Group,
+					APIVersion: policiesv1.GroupVersion.Group + "/" + policiesv1.GroupVersion.Version,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      request.Name,


### PR DESCRIPTION
The policy passed to cleanUpPolicy had invalid apiVersion field set. This caused the dynamic watch library not to clean up the watches.

Relates:
https://github.com/stolostron/backlog/issues/25866