### PR TITLE
Aggregate Pending status from replicated policies

### DIFF
--- a/controllers/propagator/aggregation.go
+++ b/controllers/propagator/aggregation.go
@@ -1,0 +1,126 @@
+package propagator
+
+import (
+	"context"
+	"sort"
+
+	retry "github.com/avast/retry-go/v3"
+	appsv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+	"open-cluster-management.io/governance-policy-propagator/controllers/common"
+)
+
+// calculatePerClusterStatus lists up all policies replicated from the input policy, and stores
+// their compliance states in the result list. Additionally, clusters in the failedClusters input
+// will be marked as NonCompliant in the result. The result is sorted by cluster name. An error
+// will be returned if lookup of the replicated policies fails, and the retries also fail.
+func (r *PolicyReconciler) calculatePerClusterStatus(
+	instance *policiesv1.Policy, failedClusters decisionSet,
+) ([]*policiesv1.CompliancePerClusterStatus, error) {
+	if instance.Spec.Disabled {
+		return nil, nil
+	}
+
+	replicatedPlcList := &policiesv1.PolicyList{}
+
+	log.V(1).Info("Getting the replicated policies")
+
+	err := retry.Do(
+		func() error {
+			return r.List(
+				context.TODO(),
+				replicatedPlcList,
+				client.MatchingLabels(LabelsForRootPolicy(instance)),
+			)
+		},
+		getRetryOptions(log.V(1), "Retrying to list the replicated policies")...,
+	)
+	if err != nil {
+		log.Info("Gave up on listing the replicated policies after too many retries")
+		r.recordWarning(instance, "Could not list the replicated policies")
+
+		return nil, err
+	}
+
+	status := make([]*policiesv1.CompliancePerClusterStatus, 0, len(replicatedPlcList.Items)+len(failedClusters))
+
+	// Update the status based on the replicated policies
+	for _, rPlc := range replicatedPlcList.Items {
+		key := appsv1.PlacementDecision{
+			ClusterName:      rPlc.GetLabels()[common.ClusterNameLabel],
+			ClusterNamespace: rPlc.GetLabels()[common.ClusterNamespaceLabel],
+		}
+
+		if failed := failedClusters[key]; failed {
+			// Skip the replicated policies that failed to be properly replicated
+			// for now. This will be handled later.
+			continue
+		}
+
+		status = append(status, &policiesv1.CompliancePerClusterStatus{
+			ComplianceState:  rPlc.Status.ComplianceState,
+			ClusterName:      key.ClusterName,
+			ClusterNamespace: key.ClusterNamespace,
+		})
+	}
+
+	// Add cluster statuses for the clusters that did not get their policies properly
+	// replicated. This is not done in the previous loop since some replicated polices may not
+	// have been created at all.
+	for clusterDecision := range failedClusters {
+		log.Info(
+			"Setting the policy to noncompliant since the replication failed", "cluster", clusterDecision,
+		)
+
+		status = append(status, &policiesv1.CompliancePerClusterStatus{
+			ComplianceState:  policiesv1.NonCompliant,
+			ClusterName:      clusterDecision.ClusterName,
+			ClusterNamespace: clusterDecision.ClusterNamespace,
+		})
+	}
+
+	sort.Slice(status, func(i, j int) bool {
+		return status[i].ClusterName < status[j].ClusterName
+	})
+
+	return status, nil
+}
+
+// calculateRootCompliance uses the input per-cluster statuses to determine what a root policy's
+// ComplianceState should be. General precedence is: NonCompliant > Pending > Unknown > Compliant.
+func calculateRootCompliance(clusters []*policiesv1.CompliancePerClusterStatus) policiesv1.ComplianceState {
+	if len(clusters) == 0 {
+		// No clusters == no status
+		return ""
+	}
+
+	unknownFound := false
+	pendingFound := false
+
+	for _, status := range clusters {
+		switch status.ComplianceState {
+		case policiesv1.NonCompliant:
+			// NonCompliant has the highest priority, so we can skip checking the others
+			return policiesv1.NonCompliant
+		case policiesv1.Pending:
+			pendingFound = true
+		case policiesv1.Compliant:
+			continue
+		default:
+			unknownFound = true
+		}
+	}
+
+	if pendingFound {
+		return policiesv1.Pending
+	}
+
+	if unknownFound {
+		return ""
+	}
+
+	// Returns compliant if, and only if, *all* cluster statuses are Compliant
+	return policiesv1.Compliant
+}

--- a/controllers/propagator/aggregation_test.go
+++ b/controllers/propagator/aggregation_test.go
@@ -1,0 +1,79 @@
+package propagator
+
+import (
+	"reflect"
+	"testing"
+
+	policiesv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+)
+
+func fakeCPCS(name, compliance string) *policiesv1.CompliancePerClusterStatus {
+	return &policiesv1.CompliancePerClusterStatus{
+		ComplianceState:  policiesv1.ComplianceState(compliance),
+		ClusterName:      name,
+		ClusterNamespace: name,
+	}
+}
+
+func TestCalculateRootCompliance(t *testing.T) {
+	allCompliantList := []*policiesv1.CompliancePerClusterStatus{
+		fakeCPCS("articuno", "Compliant"),
+		fakeCPCS("zapdos", "Compliant"),
+		fakeCPCS("moltres", "Compliant"),
+	}
+
+	tests := map[string]struct {
+		input []*policiesv1.CompliancePerClusterStatus
+		want  policiesv1.ComplianceState
+	}{
+		"all compliant": {
+			input: allCompliantList,
+			want:  policiesv1.Compliant,
+		},
+		"one noncompliant": {
+			input: append(allCompliantList, fakeCPCS("foo", "NonCompliant")),
+			want:  policiesv1.NonCompliant,
+		},
+		"one pending": {
+			input: append(allCompliantList, fakeCPCS("bar", "Pending")),
+			want:  policiesv1.Pending,
+		},
+		"one empty": {
+			input: append(allCompliantList, fakeCPCS("thud", "")),
+			want:  policiesv1.ComplianceState(""),
+		},
+		"one odd value": {
+			input: append(allCompliantList, fakeCPCS("wibble", "Discombobulated")),
+			want:  policiesv1.ComplianceState(""),
+		},
+		"noncompliant and pending": {
+			input: append(allCompliantList,
+				fakeCPCS("foo", "NonCompliant"),
+				fakeCPCS("bar", "Pending")),
+			want: policiesv1.NonCompliant,
+		},
+		"pending and unknown": {
+			input: append(allCompliantList,
+				fakeCPCS("bar", "Pending"),
+				fakeCPCS("thud", "")),
+			want: policiesv1.Pending,
+		},
+		"all states": {
+			input: append(allCompliantList,
+				fakeCPCS("foo", "NonCompliant"),
+				fakeCPCS("bar", "Pending"),
+				fakeCPCS("thud", ""),
+				fakeCPCS("wibble", "Discombobulated")),
+			want: policiesv1.NonCompliant,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := calculateRootCompliance(test.input)
+			if !reflect.DeepEqual(test.want, got) {
+				t.Fatalf("expected: %v, got: %v", test.want, got)
+			}
+		})
+	}
+}

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -266,9 +266,11 @@ func handleDecisionWrapper(
 ) {
 	for decision := range decisions {
 		log := log.WithValues(
-			"policyName", instance.GetName(), "policyNamespace", instance.GetNamespace(),
+			"policyName", instance.GetName(),
+			"policyNamespace", instance.GetNamespace(),
+			"decision", decision,
 		)
-		log.Info("Handling the decision", "identifier", decision)
+		log.Info("Handling the decision")
 
 		templateRefObjs := map[k8sdepwatches.ObjectIdentifier]bool{}
 
@@ -594,90 +596,11 @@ func (r *PolicyReconciler) handleRootPolicy(instance *policiesv1.Policy) error {
 		return errors.New("c" + msg[1:])
 	}
 
-	status := []*policiesv1.CompliancePerClusterStatus{}
+	cpcs, _ := r.calculatePerClusterStatus(instance, failedClusters)
 
-	if !instance.Spec.Disabled {
-		// Get all the replicated policies
-		replicatedPlcList := &policiesv1.PolicyList{}
+	instance.Status.Status = cpcs
+	instance.Status.ComplianceState = calculateRootCompliance(cpcs)
 
-		log.V(1).Info("Getting the replicated policies")
-
-		err := retry.Do(
-			func() error {
-				return r.List(
-					context.TODO(),
-					replicatedPlcList,
-					client.MatchingLabels(LabelsForRootPolicy(instance)),
-				)
-			},
-			getRetryOptions(log.V(1), "Retrying to list the replicated policies")...,
-		)
-		if err != nil {
-			log.Info("Gave up on listing the replicated policies after too many retries")
-			r.recordWarning(instance, "Could not list the replicated policies")
-
-			return err
-		}
-
-		// Update the status based on the replicated policies
-		for _, rPlc := range replicatedPlcList.Items {
-			key := appsv1.PlacementDecision{
-				ClusterName:      rPlc.GetLabels()[common.ClusterNameLabel],
-				ClusterNamespace: rPlc.GetLabels()[common.ClusterNamespaceLabel],
-			}
-
-			if failed := failedClusters[key]; failed {
-				// Skip the replicated policies that failed to be properly replicated
-				// for now. This will be handled later.
-				continue
-			}
-
-			status = append(status, &policiesv1.CompliancePerClusterStatus{
-				ComplianceState:  rPlc.Status.ComplianceState,
-				ClusterName:      key.ClusterName,
-				ClusterNamespace: key.ClusterNamespace,
-			})
-		}
-
-		// Add cluster statuses for the clusters that did not get their policies properly
-		// replicated. This is not done in the previous loop since some replicated polices may not
-		// have been created at all.
-		for clusterDecision := range failedClusters {
-			log.Info(
-				"Setting the policy to noncompliant since the replication failed", "cluster", clusterDecision,
-			)
-
-			status = append(status, &policiesv1.CompliancePerClusterStatus{
-				ComplianceState:  policiesv1.NonCompliant,
-				ClusterName:      clusterDecision.ClusterName,
-				ClusterNamespace: clusterDecision.ClusterNamespace,
-			})
-		}
-
-		sort.Slice(status, func(i, j int) bool {
-			return status[i].ClusterName < status[j].ClusterName
-		})
-	}
-
-	instance.Status.Status = status
-	// loop through status and set ComplianceState
-	instance.Status.ComplianceState = ""
-	isCompliant := true
-
-	for _, cpcs := range status {
-		if cpcs.ComplianceState == "NonCompliant" {
-			instance.Status.ComplianceState = policiesv1.NonCompliant
-			isCompliant = false
-
-			break
-		} else if cpcs.ComplianceState == "" {
-			isCompliant = false
-		}
-	}
-	// set to compliant only when all status are compliant
-	if len(status) > 0 && isCompliant {
-		instance.Status.ComplianceState = policiesv1.Compliant
-	}
 	// looped through all pb, update status.placement
 	sort.Slice(placements, func(i, j int) bool {
 		return placements[i].PlacementBinding < placements[j].PlacementBinding

--- a/test/resources/case2_aggregation/managed-mixed-pending-compliant.yaml
+++ b/test/resources/case2_aggregation/managed-mixed-pending-compliant.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case2-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case2-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+status:
+  compliant: Pending
+  placement:
+  - placementBinding: case2-test-policy-pb
+    placementRule: case2-test-policy-plr
+  status:
+  - clustername: managed1
+    clusternamespace: managed1
+    compliant: Compliant
+  - clustername: managed2
+    clusternamespace: managed2
+    compliant: Pending

--- a/test/resources/case2_aggregation/managed-mixed-pending-noncompliant.yaml
+++ b/test/resources/case2_aggregation/managed-mixed-pending-noncompliant.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case2-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case2-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+status:
+  compliant: NonCompliant
+  placement:
+  - placementBinding: case2-test-policy-pb
+    placementRule: case2-test-policy-plr
+  status:
+  - clustername: managed1
+    clusternamespace: managed1
+    compliant: NonCompliant
+  - clustername: managed2
+    clusternamespace: managed2
+    compliant: Pending

--- a/test/resources/case2_aggregation/managed-one-status-noncompliant.yaml
+++ b/test/resources/case2_aggregation/managed-one-status-noncompliant.yaml
@@ -1,0 +1,32 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case2-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case2-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+status:
+  compliant: NonCompliant
+  placement:
+  - placementBinding: case2-test-policy-pb
+    placementRule: case2-test-policy-plr
+  status:
+  - clustername: managed1
+    clusternamespace: managed1
+    compliant: NonCompliant
+  - clustername: managed2
+    clusternamespace: managed2
+    compliant: Compliant


### PR DESCRIPTION
When a replicated policy is in the Pending state, and all others for that root policy are Compliant, then the root policy should be Pending.

This change extracts some other aggregation logic in a way that should be more testable, and adds unit tests for some previous existing behavior.

Refs:
 - https://github.com/stolostron/backlog/issues/26182

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>