### PR TITLE
Only pass violation context when non compliant cluster exists

### DIFF
--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -872,7 +872,7 @@ var _ = Describe("Test policy automation", func() {
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(2))
 
-			By("Check each violation context field is null in extra_vars for the compliant manual run case")
+			By("Check each policy_violation_context is null in extra_vars for the compliant manual run case")
 			ansiblejobList, err = clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
 				context.TODO(), metav1.ListOptions{},
 			)
@@ -885,11 +885,13 @@ var _ = Describe("Test policy automation", func() {
 			}
 
 			extraVars = spec.(map[string]interface{})["extra_vars"].(map[string]interface{})
-			Expect(extraVars["policy_name"]).To(Equal(""))
-			Expect(extraVars["namespace"]).To(Equal(""))
-			Expect(extraVars["hub_cluster"]).To(Equal(""))
-			Expect(extraVars["target_clusters"]).To(BeNil())
-			Expect(extraVars["policy_set"]).To(BeNil())
+			Expect(extraVars["policy_name"]).To(Equal("case5-test-policy"))
+			Expect(extraVars["namespace"]).To(Equal(testNamespace))
+			By("Check hub_cluster : " + extraVars["hub_cluster"].(string))
+			Expect(len(extraVars["hub_cluster"].(string)) > 0).To(BeTrue())
+			Expect(len(extraVars["target_clusters"].([]interface{}))).To(Equal(0))
+			Expect(len(extraVars["policy_set"].([]interface{}))).To(Equal(1))
+			Expect(extraVars["policy_set"].([]interface{})[0]).To(Equal("case5-test-policyset"))
 			Expect(extraVars["policy_violation_context"]).To(BeNil())
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Chunxi Luo <chuluo@redhat.com>

Still pass policy info when all clusters are compliant, just skip violation context 