### PR TITLE
enable pending status for policy set

### DIFF
--- a/test/resources/case11_policyset_controller/case11-statuscheck-7.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-7.yaml
@@ -13,5 +13,5 @@ status:
   - placementBinding: case11-multistatus-policyset-pb
     placementRule: case11-multistatus-policyset-plr
   statusMessage: "Disabled policies: case11-test-disabled; No status provided while
-    policies are pending: case11-test-message-policy; Deleted policies: case11-does-not-exist,
+    awaiting policy status: case11-test-message-policy; Deleted policies: case11-does-not-exist,
     case11-deleted-policy"

--- a/test/resources/case11_policyset_controller/case11-statuscheck-8.yaml
+++ b/test/resources/case11_policyset_controller/case11-statuscheck-8.yaml
@@ -1,0 +1,13 @@
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: PolicySet
+metadata:
+  name: case11-test-policyset
+spec:
+  policies:
+  - case11-test-policy
+status:
+  compliant: Pending
+  placement:
+  - placementBinding: case11-test-policyset-pb
+    placementRule: case11-test-policyset-plr
+  statusMessage: "Policies awaiting pending dependencies: case11-test-policy"


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Allows the status of a `PolicySet` to be `pending`. The compliance state for the policy set follows the same rules as parent policies - if a policy set contains pending policies, the status will be pending unless there are noncompliant policies as well, in which case the policy set will be noncompliant.

The PR also changes the wording of the status message that shows up in a policy set when some policies in the set do not have a status. Previously it referred to those policies as pending, which could be easily confused with policies with the pending compliance state. In order to avoid this confusion, this PR changes the wording from pending policies to policies that are awaiting status.

Needed for https://issues.redhat.com/browse/ACM-2101 and https://issues.redhat.com/browse/ACM-2165