### PR TITLE
Add CRD validation for namespaces in dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,10 @@ KUSTOMIZE = $(LOCAL_BIN)/kustomize
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: kustomize controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=governance-policy-propagator paths="./..." output:crd:artifacts:config=deploy/crds output:rbac:artifacts:config=deploy/rbac
+	mv deploy/crds/policy.open-cluster-management.io_policies.yaml deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
+	$(KUSTOMIZE) build deploy/crds/kustomize > deploy/crds/policy.open-cluster-management.io_policies.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/deploy/crds/kustomize/kustomization.yaml
+++ b/deploy/crds/kustomize/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- policy.open-cluster-management.io_policies.yaml
+
+# Add validation more complicated than Kubebuilder markers can provide
+patches:
+- path: ns-validation.json
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: policies.policy.open-cluster-management.io

--- a/deploy/crds/kustomize/ns-validation.json
+++ b/deploy/crds/kustomize/ns-validation.json
@@ -1,0 +1,33 @@
+[
+    {
+        "op":"add",
+        "path":"/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/dependencies/items/oneOf",
+        "value": [{
+            "properties": {
+                "kind": {"enum": ["CertificatePolicy", "ConfigurationPolicy","IamPolicy"]},
+                "namespace": {"maxLength": 0}
+            }
+        },{
+            "not": {
+                "properties": {
+                    "kind": {"pattern": "^(?:(?:Certificate|Configuration|Iam)Policy)$"}
+                }
+            }
+        }]
+    },{
+        "op":"add",
+        "path":"/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/policy-templates/items/properties/extraDependencies/items/oneOf",
+        "value": [{
+            "properties": {
+                "kind": {"enum": ["CertificatePolicy", "ConfigurationPolicy","IamPolicy"]},
+                "namespace": {"maxLength": 0}
+            }
+        },{
+            "not": {
+                "properties": {
+                    "kind": {"pattern": "^(?:(?:Certificate|Configuration|Iam)Policy)$"}
+                }
+            }
+        }]
+    }
+]

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -53,19 +55,6 @@ spec:
                   description: Each PolicyDepenency defines an object reference which
                     must be in a certain compliance state before the policy should
                     be created.
-                  oneOf:
-                  - properties:
-                      kind:
-                        enum:
-                        - CertificatePolicy
-                        - ConfigurationPolicy
-                        - IamPolicy
-                      namespace:
-                        maxLength: 0
-                  - not:
-                      properties:
-                        kind:
-                          pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                   properties:
                     apiVersion:
                       description: 'APIVersion defines the versioned schema of this
@@ -111,19 +100,6 @@ spec:
                         description: Each PolicyDepenency defines an object reference
                           which must be in a certain compliance state before the policy
                           should be created.
-                        oneOf:
-                        - properties:
-                            kind:
-                              enum:
-                              - CertificatePolicy
-                              - ConfigurationPolicy
-                              - IamPolicy
-                            namespace:
-                              maxLength: 0
-                        - not:
-                            properties:
-                              kind:
-                                pattern: ^(?:(?:Certificate|Configuration|Iam)Policy)$
                         properties:
                           apiVersion:
                             description: 'APIVersion defines the versioned schema

--- a/test/e2e/case15_dep_crd_validation_test.go
+++ b/test/e2e/case15_dep_crd_validation_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+var _ = Describe("Test CRD validation", func() {
+	basicPolicy := func() *unstructured.Unstructured {
+		return utils.ParseYaml("../resources/case15_dep_crd_validation/basic-policy.yaml")
+	}
+
+	addDependency := func(pol *unstructured.Unstructured, name, ns, kind string) *unstructured.Unstructured {
+		deps := []interface{}{map[string]interface{}{
+			"apiVersion": "policy.open-cluster-management.io/v1",
+			"kind":       kind,
+			"name":       name,
+			"namespace":  ns,
+			"compliance": "Compliant",
+		}}
+
+		err := unstructured.SetNestedSlice(pol.Object, deps, "spec", "dependencies")
+		Expect(err).To(BeNil())
+
+		return pol
+	}
+
+	addExtraDependency := func(pol *unstructured.Unstructured, name, ns, kind string) *unstructured.Unstructured {
+		templates, found, err := unstructured.NestedSlice(pol.Object, "spec", "policy-templates")
+		Expect(found).To(BeTrue())
+		Expect(err).To(BeNil())
+
+		tmpl0 := templates[0].(map[string]interface{})
+		tmpl0["extraDependencies"] = []interface{}{map[string]interface{}{
+			"apiVersion": "policy.open-cluster-management.io/v1",
+			"kind":       kind,
+			"name":       name,
+			"namespace":  ns,
+			"compliance": "Compliant",
+		}}
+
+		err = unstructured.SetNestedSlice(pol.Object, templates, "spec", "policy-templates")
+		Expect(err).To(BeNil())
+
+		return pol
+	}
+
+	policyClient := func() dynamic.ResourceInterface {
+		return clientHubDynamic.Resource(gvrPolicy).Namespace("default")
+	}
+
+	AfterEach(func() {
+		By("Removing the policy")
+		// ignore error, because invalid policies will not have been created
+		_ = policyClient().Delete(context.TODO(), "basic", v1.DeleteOptions{})
+	})
+
+	Describe("Test dependency namespace validation", func() {
+		tests := map[string]struct {
+			validWithNamespace    bool
+			validWithoutNamespace bool
+		}{
+			"ConfigurationPolicy": {false, true},
+			"CertificatePolicy":   {false, true},
+			"IamPolicy":           {false, true},
+			"Policy":              {true, true},
+			"PolicySet":           {true, true},
+			"OtherType":           {true, true},
+		}
+
+		for kind, tc := range tests {
+			kind := kind
+			tc := tc
+
+			It("checks creating a policy with a "+kind+" dependency with a namespace", func() {
+				pol := addDependency(basicPolicy(), "foo", "default", kind)
+				_, err := policyClient().Create(context.TODO(), pol, v1.CreateOptions{})
+				Expect(err == nil).To(Equal(tc.validWithNamespace))
+			})
+			It("checks creating a policy with a "+kind+" dependency without a namespace", func() {
+				pol := addDependency(basicPolicy(), "foo", "", kind)
+				_, err := policyClient().Create(context.TODO(), pol, v1.CreateOptions{})
+				Expect(err == nil).To(Equal(tc.validWithoutNamespace))
+			})
+		}
+	})
+
+	Describe("Test extraDependency namespace validation", func() {
+		tests := map[string]struct {
+			validWithNamespace    bool
+			validWithoutNamespace bool
+		}{
+			"ConfigurationPolicy": {false, true},
+			"CertificatePolicy":   {false, true},
+			"IamPolicy":           {false, true},
+			"Policy":              {true, true},
+			"PolicySet":           {true, true},
+			"OtherType":           {true, true},
+		}
+
+		for kind, tc := range tests {
+			kind := kind
+			tc := tc
+
+			It("checks creating a policy with a "+kind+" extraDependency with a namespace", func() {
+				pol := addExtraDependency(basicPolicy(), "foo", "default", kind)
+				_, err := policyClient().Create(context.TODO(), pol, v1.CreateOptions{})
+				Expect(err == nil).To(Equal(tc.validWithNamespace))
+			})
+			It("checks creating a policy with a "+kind+" extraDependency without a namespace", func() {
+				pol := addExtraDependency(basicPolicy(), "foo", "", kind)
+				_, err := policyClient().Create(context.TODO(), pol, v1.CreateOptions{})
+				Expect(err == nil).To(Equal(tc.validWithoutNamespace))
+			})
+		}
+	})
+})

--- a/test/resources/case15_dep_crd_validation/basic-policy.yaml
+++ b/test/resources/case15_dep_crd_validation/basic-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: basic
+  namespace: default
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: mytrustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io


### PR DESCRIPTION
It is invalid to set a namespace on dependencies from our known types (ConfigurationPolicy, IamPolicy, CertificatePolicy), because those will be in the clusternamespace on the managed cluster.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>