### PR TITLE
Fix format of policy CRD yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 manifests: kustomize controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=governance-policy-propagator paths="./..." output:crd:artifacts:config=deploy/crds output:rbac:artifacts:config=deploy/rbac
 	mv deploy/crds/policy.open-cluster-management.io_policies.yaml deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
-	$(KUSTOMIZE) build deploy/crds/kustomize > deploy/crds/policy.open-cluster-management.io_policies.yaml
+	@echo "\n---" > deploy/crds/policy.open-cluster-management.io_policies.yaml
+	$(KUSTOMIZE) build deploy/crds/kustomize >> deploy/crds/policy.open-cluster-management.io_policies.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/deploy/crds/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Since the CRDs are synchronized across multiple repositories, the format needs to be kept consistent.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>