### PR TITLE
Add a metric to record policy propagation failures

### DIFF
--- a/controllers/propagator/metric.go
+++ b/controllers/propagator/metric.go
@@ -15,6 +15,13 @@ var (
 			Help: "The number of active watch API requests for Hub policy templates",
 		},
 	)
+	propagationFailureMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "policy_propagation_failure_total",
+			Help: "The number of failed policy propagation attempts per policy",
+		},
+		[]string{"name", "namespace"},
+	)
 	roothandlerMeasure = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Name: "ocm_handle_root_policy_duration_seconds_bucket",
 		Help: "Time the handleRootPolicy function takes to complete.",
@@ -23,5 +30,6 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(roothandlerMeasure)
+	metrics.Registry.MustRegister(propagationFailureMetric)
 	metrics.Registry.MustRegister(hubTemplateActiveWatchesMetric)
 }

--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -155,6 +155,8 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		// requeue it to be reprocessed later.
 		err := r.handleRootPolicy(instance)
 		if err != nil {
+			propagationFailureMetric.WithLabelValues(instance.GetName(), instance.GetNamespace()).Inc()
+
 			r.recordWarning(
 				instance,
 				fmt.Sprintf("Retrying the request in %d minutes", requeueErrorDelay),


### PR DESCRIPTION
This excludes a test because all failures that would trigger the metric to increment are API related and would be difficult to mock.

Relates:
https://issues.redhat.com/browse/ACM-2397

Signed-off-by: mprahl <mprahl@users.noreply.github.com>