### PR TITLE
Use printf instead of echo for changing CRD format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 manifests: kustomize controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=governance-policy-propagator paths="./..." output:crd:artifacts:config=deploy/crds output:rbac:artifacts:config=deploy/rbac
 	mv deploy/crds/policy.open-cluster-management.io_policies.yaml deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
-	@echo "\n---" > deploy/crds/policy.open-cluster-management.io_policies.yaml
+	# Add a newline so that the format matches what kubebuilder generates
+	@printf "\n---\n" > deploy/crds/policy.open-cluster-management.io_policies.yaml
 	$(KUSTOMIZE) build deploy/crds/kustomize >> deploy/crds/policy.open-cluster-management.io_policies.yaml
 
 .PHONY: generate


### PR DESCRIPTION
Some systems require `echo -e` whereas for others it doesn't work. printf works in both cases.