### PR TITLE
Use enum for dependency compliance

### DIFF
--- a/api/v1/policy_types.go
+++ b/api/v1/policy_types.go
@@ -60,7 +60,8 @@ type PolicyDependency struct {
 	Namespace string `json:"namespace,omitempty"`
 
 	// The ComplianceState (at path .status.compliant) required before the policy should be created
-	Compliance string `json:"compliance"`
+	// +kubebuilder:validation:Enum=Compliant;Pending;NonCompliant
+	Compliance ComplianceState `json:"compliance"`
 }
 
 // PolicySpec defines the desired state of Policy

--- a/controllers/propagator/replication_test.go
+++ b/controllers/propagator/replication_test.go
@@ -71,7 +71,7 @@ func fakeDependencyFromObj(obj client.Object, compliance string) policiesv1.Poli
 		},
 		Name:       obj.GetName(),
 		Namespace:  obj.GetNamespace(),
-		Compliance: compliance,
+		Compliance: policiesv1.ComplianceState(compliance),
 	}
 }
 

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
@@ -65,6 +65,10 @@ spec:
                     compliance:
                       description: The ComplianceState (at path .status.compliant)
                         required before the policy should be created
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                     kind:
                       description: 'Kind is a string value representing the REST resource
@@ -110,6 +114,10 @@ spec:
                           compliance:
                             description: The ComplianceState (at path .status.compliant)
                               required before the policy should be created
+                            enum:
+                            - Compliant
+                            - Pending
+                            - NonCompliant
                             type: string
                           kind:
                             description: 'Kind is a string value representing the

--- a/deploy/crds/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies.yaml
@@ -78,6 +78,10 @@ spec:
                     compliance:
                       description: The ComplianceState (at path .status.compliant)
                         required before the policy should be created
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                     kind:
                       description: 'Kind is a string value representing the REST resource
@@ -136,6 +140,10 @@ spec:
                           compliance:
                             description: The ComplianceState (at path .status.compliant)
                               required before the policy should be created
+                            enum:
+                            - Compliant
+                            - Pending
+                            - NonCompliant
                             type: string
                           kind:
                             description: 'Kind is a string value representing the


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Adds an enum for dependencies[].compliance and extraDependencies[].compliance to block creation of policies with that field set incorrectly. This will fix policies creating with invalid dependencies.

refs:

https://issues.redhat.com/browse/ACM-2148