### PR TITLE
Provide the correct Hub DNS name in the Ansible extra_vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,7 @@ install-crds: manifests
 	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/api/main/cluster/v1beta1/0000_02_clusters.open-cluster-management.io_placements.crd.yaml --validate=false
 	kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/api/main/cluster/v1beta1/0000_03_clusters.open-cluster-management.io_placementdecisions.crd.yaml --validate=false
 	kubectl apply -f deploy/crds/external/tower.ansible.com_joblaunch_crd.yaml
+	kubectl apply -f test/resources/case5_policy_automation/dns-crd.yaml
 
 .PHONY: install-resources
 install-resources:
@@ -272,6 +273,8 @@ install-resources:
 	@echo creating cluster resources
 	kubectl apply -f test/resources/managed1-cluster.yaml
 	kubectl apply -f test/resources/managed2-cluster.yaml
+	@echo setting a Hub cluster DNS name
+	kubectl apply -f test/resources/case5_policy_automation/cluster-dns.yaml
 
 .PHONY: e2e-dependencies
 e2e-dependencies:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -74,6 +74,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resourceNames:
+  - cluster
+  resources:
+  - dnses
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -33,6 +33,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resourceNames:
+  - cluster
+  resources:
+  - dnses
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -172,10 +172,7 @@ var _ = Describe("Test policy automation", func() {
 			extraVars := spec.(map[string]interface{})["extra_vars"].(map[string]interface{})
 			Expect(extraVars["policy_name"]).To(Equal("case5-test-policy"))
 			Expect(extraVars["namespace"]).To(Equal(testNamespace))
-			// hub_cluster depends on environment so just check if hub_cluster is set
-			// rather than verifying the hub_cluster name
-			By("Check hub_cluster : " + extraVars["hub_cluster"].(string))
-			Expect(len(extraVars["hub_cluster"].(string)) > 0).To(BeTrue())
+			Expect(extraVars["hub_cluster"]).To(Equal("millienium-falcon.tatooine.local"))
 			Expect(len(extraVars["target_clusters"].([]interface{}))).To(Equal(1))
 			Expect(extraVars["target_clusters"].([]interface{})[0]).To(Equal("managed1"))
 			Expect(len(extraVars["policy_set"].([]interface{}))).To(Equal(1))
@@ -811,10 +808,7 @@ var _ = Describe("Test policy automation", func() {
 			extraVars := spec.(map[string]interface{})["extra_vars"].(map[string]interface{})
 			Expect(extraVars["policy_name"]).To(Equal("case5-test-policy"))
 			Expect(extraVars["namespace"]).To(Equal(testNamespace))
-			// hub_cluster depends on environment so just check if hub_cluster is set
-			// rather than verifying the hub_cluster name
-			By("Check hub_cluster : " + extraVars["hub_cluster"].(string))
-			Expect(len(extraVars["hub_cluster"].(string)) > 0).To(BeTrue())
+			Expect(extraVars["hub_cluster"]).To(Equal("millienium-falcon.tatooine.local"))
 			Expect(len(extraVars["target_clusters"].([]interface{}))).To(Equal(2))
 			Expect(len(extraVars["policy_set"].([]interface{}))).To(Equal(1))
 			Expect(extraVars["policy_set"].([]interface{})[0]).To(Equal("case5-test-policyset"))
@@ -872,7 +866,7 @@ var _ = Describe("Test policy automation", func() {
 				return len(ansiblejobList.Items)
 			}, 30, 1).Should(Equal(2))
 
-			By("Check each policy_violation_context is null in extra_vars for the compliant manual run case")
+			By("Check the policy_violation_context is mostly empty for the compliant manual run case")
 			ansiblejobList, err = clientHubDynamic.Resource(gvrAnsibleJob).Namespace(testNamespace).List(
 				context.TODO(), metav1.ListOptions{},
 			)
@@ -887,8 +881,7 @@ var _ = Describe("Test policy automation", func() {
 			extraVars = spec.(map[string]interface{})["extra_vars"].(map[string]interface{})
 			Expect(extraVars["policy_name"]).To(Equal("case5-test-policy"))
 			Expect(extraVars["namespace"]).To(Equal(testNamespace))
-			By("Check hub_cluster : " + extraVars["hub_cluster"].(string))
-			Expect(len(extraVars["hub_cluster"].(string)) > 0).To(BeTrue())
+			Expect(extraVars["hub_cluster"]).To(Equal("millienium-falcon.tatooine.local"))
 			Expect(len(extraVars["target_clusters"].([]interface{}))).To(Equal(0))
 			Expect(len(extraVars["policy_set"].([]interface{}))).To(Equal(1))
 			Expect(extraVars["policy_set"].([]interface{})[0]).To(Equal("case5-test-policyset"))

--- a/test/resources/case5_policy_automation/cluster-dns.yaml
+++ b/test/resources/case5_policy_automation/cluster-dns.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: DNS
+metadata:
+  name: cluster
+spec:
+  baseDomain: millienium-falcon.tatooine.local

--- a/test/resources/case5_policy_automation/dns-crd.yaml
+++ b/test/resources/case5_policy_automation/dns-crd.yaml
@@ -1,0 +1,135 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  creationTimestamp: "2023-01-09T07:07:25Z"
+  generation: 1
+  name: dnses.config.openshift.io
+  ownerReferences:
+  - apiVersion: config.openshift.io/v1
+    kind: ClusterVersion
+    name: version
+    uid: ace25b63-dff4-415f-9c1d-c7583b57e40d
+  resourceVersion: "1100"
+  uid: 37084ebf-13f5-4c39-a9ff-fda238db6a3f
+spec:
+  conversion:
+    strategy: None
+  group: config.openshift.io
+  names:
+    kind: DNS
+    listKind: DNSList
+    plural: dnses
+    singular: dns
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: "DNS holds cluster-wide information about DNS. The canonical
+          name is `cluster` \n Compatibility level 1: Stable within a major release
+          for a minimum of 12 months or 3 minor releases (whichever is longer)."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              baseDomain:
+                description: "baseDomain is the base domain of the cluster. All managed
+                  DNS records will be sub-domains of this base. \n For example, given
+                  the base domain `openshift.example.com`, an API server DNS record
+                  may be created for `cluster-api.openshift.example.com`. \n Once
+                  set, this field cannot be changed."
+                type: string
+              privateZone:
+                description: "privateZone is the location where all the DNS records
+                  that are only available internally to the cluster exist. \n If this
+                  field is nil, no private records should be created. \n Once set,
+                  this field cannot be changed."
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                type: object
+              publicZone:
+                description: "publicZone is the location where all the DNS records
+                  that are publicly accessible to the internet exist. \n If this field
+                  is nil, no public records should be created. \n Once set, this field
+                  cannot be changed."
+                properties:
+                  id:
+                    description: "id is the identifier that can be used to find the
+                      DNS hosted zone. \n on AWS zone can be fetched using `ID` as
+                      id in [1] on Azure zone can be fetched using `ID` as a pre-determined
+                      name in [2], on GCP zone can be fetched using `ID` as a pre-determined
+                      name in [3]. \n [1]: https://docs.aws.amazon.com/cli/latest/reference/route53/get-hosted-zone.html#options
+                      [2]: https://docs.microsoft.com/en-us/cli/azure/network/dns/zone?view=azure-cli-latest#az-network-dns-zone-show
+                      [3]: https://cloud.google.com/dns/docs/reference/v1/managedZones/get"
+                    type: string
+                  tags:
+                    additionalProperties:
+                      type: string
+                    description: "tags can be used to query the DNS hosted zone. \n
+                      on AWS, resourcegroupstaggingapi [1] can be used to fetch a
+                      zone using `Tags` as tag-filters, \n [1]: https://docs.aws.amazon.com/cli/latest/reference/resourcegroupstaggingapi/get-resources.html#options"
+                    type: object
+                type: object
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: DNS
+    listKind: DNSList
+    plural: dnses
+    singular: dns
+  conditions:
+  - lastTransitionTime: "2023-01-09T07:07:25Z"
+    message: no conflicts found
+    reason: NoConflicts
+    status: "True"
+    type: NamesAccepted
+  - lastTransitionTime: "2023-01-09T07:07:25Z"
+    message: the initial names have been accepted
+    reason: InitialNamesAccepted
+    status: "True"
+    type: Established
+  storedVersions:
+  - v1


### PR DESCRIPTION
Using the Kubernetes configuration leads to a local DNS name when running in the cluster. This commit changes it to use the OpenShift dnses custom resource to get the value. Other Kubernetes distributions could have their own implementations added later.

Relates:
https://issues.redhat.com/browse/ACM-2410