### PR TITLE
Fix reconciling a policy with a dot in its name

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -188,15 +188,16 @@ func GetNumWorkers(listLength int, concurrencyPerPolicy int) int {
 }
 
 func ParseRootPolicyLabel(rootPlc string) (name, namespace string, err error) {
-	rootSplit := strings.Split(rootPlc, ".")
-	if len(rootSplit) != 2 {
-		err = fmt.Errorf("required exactly one `.` in value of label `%v`: %w",
+	// namespaces can't have a `.` (but names can) so this always correctly pulls the namespace out
+	namespace, name, found := strings.Cut(rootPlc, ".")
+	if !found {
+		err = fmt.Errorf("required at least one `.` in value of label `%v`: %w",
 			RootPolicyLabel, ErrInvalidLabelValue)
 
 		return "", "", err
 	}
 
-	return rootSplit[1], rootSplit[0], nil
+	return name, namespace, nil
 }
 
 // TypeConverter is a helper function to converter type struct a to b

--- a/controllers/common/common_test.go
+++ b/controllers/common/common_test.go
@@ -10,7 +10,7 @@ func TestParseRootPolicyLabel(t *testing.T) {
 	}{
 		"foobar":   {"", "", true},
 		"foo.bar":  {"bar", "foo", false},
-		"fo.ob.ar": {"", "", true},
+		"fo.ob.ar": {"ob.ar", "fo", false},
 	}
 
 	for input, expected := range tests {


### PR DESCRIPTION
Namespaces are required to be valid RFC 1123 DNS labels, so they do not have a `.` in their names. But that is not required for names of other objects, like this code might have assumed. So when a policy had a name like `foo.bar`, an error was occurring, which prevented the root policy from getting a status update.

Refs:
 - https://issues.redhat.com/browse/ACM-2712

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>