### PR TITLE
Add the spec.copyPolicyMetadata field

### DIFF
--- a/api/v1/policy_types.go
+++ b/api/v1/policy_types.go
@@ -69,6 +69,12 @@ type PolicySpec struct {
 	// This provides the ability to enable and disable your policies.
 	Disabled bool `json:"disabled"`
 
+	// If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
+	// If set to false, only the policy framework specific policy labels and annotations will be copied to the
+	// replicated policy.
+	// +kubebuilder:validation:Optional
+	CopyPolicyMetadata *bool `json:"copyPolicyMetadata,omitempty"`
+
 	// This value (Enforce or Inform) will override the remediationAction on each template
 	RemediationAction RemediationAction `json:"remediationAction,omitempty"`
 

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
@@ -48,6 +48,12 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
+              copyPolicyMetadata:
+                description: If set to true (default), all the policy's labels and
+                  annotations will be copied to the replicated policy. If set to false,
+                  only the policy framework specific policy labels and annotations
+                  will be copied to the replicated policy.
+                type: boolean
               dependencies:
                 description: PolicyDependencies that apply to each template in this
                   Policy

--- a/deploy/crds/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies.yaml
@@ -48,6 +48,12 @@ spec:
           spec:
             description: PolicySpec defines the desired state of Policy
             properties:
+              copyPolicyMetadata:
+                description: If set to true (default), all the policy's labels and
+                  annotations will be copied to the replicated policy. If set to false,
+                  only the policy framework specific policy labels and annotations
+                  will be copied to the replicated policy.
+                type: boolean
               dependencies:
                 description: PolicyDependencies that apply to each template in this
                   Policy


### PR DESCRIPTION
This new field allows a replicated policy to not have labels and annotations that are not managed by the policy framework. This is useful in the case where policies are deployed with ArgoCD and you don't want them to show up in the ArgoCD UI.

Additionally, the argocd.argoproj.io/compare-options annotation is now always set to IgnoreExtraneous on the replicated policies to avoid ArgoCD trying to manage the replicated policies.

Relates:
https://issues.redhat.com/browse/ACM-1690