### PR TITLE
Stop overriding default annotations when IV annotation is set

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -808,7 +808,7 @@ func (r *PolicyReconciler) handleDecision(
 	if policyHasTemplates(desiredReplicatedPolicy) {
 		// If the replicated policy has an initialization vector specified, set it for processing
 		if initializationVector, ok := replicatedPlc.Annotations[IVAnnotation]; ok {
-			tempAnnotations := replicatedPlc.GetAnnotations()
+			tempAnnotations := desiredReplicatedPolicy.GetAnnotations()
 			if tempAnnotations == nil {
 				tempAnnotations = make(map[string]string)
 			}


### PR DESCRIPTION
If the policy uses templates with encryption, the desired replicated policy should not get its default annotations overridden.

Relates:
https://issues.redhat.com/browse/ACM-1690