### PR TITLE
Add support for the copy template functions to the propagator

### DIFF
--- a/test/e2e/case9_templates_test.go
+++ b/test/e2e/case9_templates_test.go
@@ -29,6 +29,9 @@ const (
 	case9EncryptionSecretName         = "policy-encryption-key"
 	case9SecretName                   = "case9-secret"
 	IVAnnotation                      = "policy.open-cluster-management.io/encryption-iv"
+	case9PolicyNameCopy               = "case9-test-policy-copy"
+	case9PolicyYamlCopy               = "../resources/case9_templates/case9-test-policy_copy.yaml"
+	case9PolicyYamlCopiedRepl         = "../resources/case9_templates/case9-test-replpolicy_copied-"
 )
 
 var _ = Describe("Test policy templates", func() {
@@ -278,6 +281,159 @@ var _ = Describe("Test encrypted policy templates", func() {
 				utils.Kubectl("delete", "-f", case9PolicyYamlEncrypted, "-n", testNamespace)
 				opt := metav1.ListOptions{}
 				utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, defaultTimeoutSeconds)
+			})
+		}
+	})
+})
+
+var _ = Describe("Test encrypted policy templates with secret copy", func() {
+	Describe("Create policy, placement and referenced resource in ns: "+testNamespace, Ordered, func() {
+		for i := 1; i <= 2; i++ {
+			managedCluster := "managed" + fmt.Sprint(i)
+
+			It("should be created in user ns", func() {
+				By("Creating " + case9PolicyYamlCopy)
+				utils.Kubectl("apply",
+					"-f", case9PolicyYamlCopy,
+					"-n", testNamespace)
+				plc := utils.GetWithTimeout(
+					clientHubDynamic, gvrPolicy, case9PolicyNameCopy, testNamespace,
+					true, defaultTimeoutSeconds,
+				)
+				Expect(plc).NotTo(BeNil())
+			})
+
+			It("should resolve templates and propagate to cluster ns "+managedCluster, func() {
+				By("Initializing AES Encryption Secret")
+				_, err := utils.KubectlWithOutput("apply",
+					"-f", case9EncryptionSecret,
+					"-n", managedCluster)
+				Expect(err).To(BeNil())
+
+				By("Patching test-policy-plr with decision of cluster " + managedCluster)
+				plr := utils.GetWithTimeout(
+					clientHubDynamic, gvrPlacementRule, case9PolicyNameCopy+"-plr", testNamespace,
+					true, defaultTimeoutSeconds,
+				)
+				plr.Object["status"] = utils.GeneratePlrStatus(managedCluster)
+				_, err = clientHubDynamic.Resource(gvrPlacementRule).Namespace(testNamespace).UpdateStatus(
+					context.TODO(), plr, metav1.UpdateOptions{},
+				)
+				Expect(err).To(BeNil())
+
+				var replicatedPlc *unstructured.Unstructured
+				By("Waiting for encrypted values")
+				Eventually(func() interface{} {
+					replicatedPlc = utils.GetWithTimeout(
+						clientHubDynamic,
+						gvrPolicy,
+						testNamespace+"."+case9PolicyNameCopy,
+						managedCluster,
+						true,
+						defaultTimeoutSeconds,
+					)
+
+					return fmt.Sprint(replicatedPlc.Object["spec"])
+				}, defaultTimeoutSeconds, 1).Should(ContainSubstring("$ocm_encrypted:"))
+
+				By("Patching the initialization vector with a static value")
+				// Setting Initialization Vector so that the test results will be deterministic
+				initializationVector := "7cznVUq5SXEE4RMZNkGOrQ=="
+				annotations := replicatedPlc.GetAnnotations()
+				annotations[IVAnnotation] = initializationVector
+				replicatedPlc.SetAnnotations(annotations)
+				_, err = clientHubDynamic.Resource(gvrPolicy).Namespace(managedCluster).Update(
+					context.TODO(), replicatedPlc, metav1.UpdateOptions{},
+				)
+				Expect(err).To(BeNil())
+
+				By("Verifying the replicated policy against a snapshot")
+				yamlPlc := utils.ParseYaml(case9PolicyYamlCopiedRepl + managedCluster + ".yaml")
+				Eventually(func() interface{} {
+					replicatedPlc = utils.GetWithTimeout(
+						clientHubDynamic,
+						gvrPolicy,
+						testNamespace+"."+case9PolicyNameCopy,
+						managedCluster,
+						true,
+						defaultTimeoutSeconds,
+					)
+
+					return replicatedPlc.Object["spec"]
+				}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
+			})
+
+			It("should reconcile when the secret referenced in the template is updated", func() {
+				By("Updating the secret " + case9SecretName)
+				newToken := "THVrZS4gSSBhbSB5b3VyIGZhdGhlci4="
+				patch := []byte(`{"data": {"token": "` + newToken + `"}}`)
+				_, err := clientHub.CoreV1().Secrets(testNamespace).Patch(
+					context.TODO(), case9SecretName, types.StrategicMergePatchType, patch, metav1.PatchOptions{},
+				)
+				Expect(err).To(BeNil())
+
+				By("Verifying the replicated policy was updated")
+				expected := "$ocm_encrypted:dbHPzG98PxV7RXcAx25mMGPBAUbfjJTEMyFc7kE2W7U3FW5+X31LkidHu/25ic4m"
+				Eventually(func() string {
+					replicatedPlc := utils.GetWithTimeout(
+						clientHubDynamic,
+						gvrPolicy,
+						testNamespace+"."+case9PolicyNameCopy,
+						managedCluster,
+						true,
+						defaultTimeoutSeconds,
+					)
+
+					templates, _, _ := unstructured.NestedSlice(replicatedPlc.Object, "spec", "policy-templates")
+					if len(templates) < 1 {
+						return ""
+					}
+
+					template, ok := templates[0].(map[string]interface{})
+					if !ok {
+						return ""
+					}
+
+					objectTemplates, _, _ := unstructured.NestedSlice(
+						template, "objectDefinition", "spec", "object-templates",
+					)
+					if len(objectTemplates) < 1 {
+						return ""
+					}
+
+					objectTemplate, ok := objectTemplates[0].(map[string]interface{})
+					if !ok {
+						return ""
+					}
+
+					secretValue, _, _ := unstructured.NestedString(
+						objectTemplate, "objectDefinition", "data", "token",
+					)
+
+					return secretValue
+				}, defaultTimeoutSeconds, 1).Should(Equal(expected))
+			})
+
+			It("should clean up the encryption key", func() {
+				utils.Kubectl("delete", "secret",
+					case9EncryptionSecretName,
+					"-n", managedCluster)
+				utils.GetWithTimeout(
+					clientHubDynamic, gvrSecret, case9EncryptionSecretName, managedCluster,
+					false, defaultTimeoutSeconds,
+				)
+			})
+
+			It("should clean up", func() {
+				utils.Kubectl("delete", "-f", case9PolicyYamlCopy, "-n", testNamespace)
+				opt := metav1.ListOptions{}
+				utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, defaultTimeoutSeconds)
+			})
+			AfterAll(func() {
+				utils.Kubectl("delete", "secret",
+					case9EncryptionSecretName,
+					"-n", managedCluster)
+				utils.Kubectl("delete", "-f", case9PolicyYamlCopy, "-n", testNamespace)
 			})
 		}
 	})

--- a/test/resources/case9_templates/case9-test-policy_copy.yaml
+++ b/test/resources/case9_templates/case9-test-policy_copy.yaml
@@ -1,0 +1,84 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case9-test-policy-copy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap
+                  namespace: test
+                data: '{{hub copySecretData "policy-propagator-test" "case9-secret" hub}}'
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap2
+                  namespace: test
+                data:
+                  # Configuration values can be set as key-value properties
+                  thisOtherThing: |-
+                    {{hub printf "%s" .ManagedClusterName | protect hub}}
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case9-test-policy-copy-pb
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: case9-test-policy-copy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: case9-test-policy-copy
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: case9-test-policy-copy-plr
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      []
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: case9-config
+data:
+  managed1-vlanid: "123"
+  managed2-vlanid: "456"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: case9-secret
+data:
+  token: RG8uCk9yIGRvIG5vdC4KVGhlcmUgaXMgbm8gdHJ5Lgo=
+  password: cGFzc3dvcmQK

--- a/test/resources/case9_templates/case9-test-replpolicy_copied-managed1.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy_copied-managed1.yaml
@@ -1,0 +1,49 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+  name: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          annotations:
+            "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap
+                  namespace: test
+                data:
+                  token: $ocm_encrypted:5n8twYYcFOIYqFznODvRPlMsZ9iGWUoyIDWml4HTPkrG5JX2/TLF63sfvDZD9fvP
+                  password: $ocm_encrypted:RX6KfjpLBTFhlAFIzm0kKA==
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          annotations:
+            "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap2
+                  namespace: test
+                data:
+                  thisOtherThing: $ocm_encrypted:1HozXUTNSEo5uNOKK0ninA==

--- a/test/resources/case9_templates/case9-test-replpolicy_copied-managed2.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy_copied-managed2.yaml
@@ -1,0 +1,49 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+  name: case9-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          annotations:
+            "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap
+                  namespace: test
+                data:
+                  token: $ocm_encrypted:5n8twYYcFOIYqFznODvRPlMsZ9iGWUoyIDWml4HTPkrG5JX2/TLF63sfvDZD9fvP
+                  password: $ocm_encrypted:RX6KfjpLBTFhlAFIzm0kKA==
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          annotations:
+            "policy.open-cluster-management.io/encryption-iv": "7cznVUq5SXEE4RMZNkGOrQ=="
+          name: case9-test-configpolicy
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                kind: ConfigMap
+                apiVersion: v1
+                metadata:
+                  name: case9-test-configmap2
+                  namespace: test
+                data:
+                  thisOtherThing: $ocm_encrypted:oW1OaQWTqTspUDlgLFelRQ==


### PR DESCRIPTION
Adding the `copyConfigMapData` and the `copySecretData` template functions to the policy propagator.

Refs:
 - https://issues.redhat.com/browse/ACM-2611