### PR TITLE
Requeue propagation errors

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -32,18 +32,6 @@ import (
 	"open-cluster-management.io/governance-policy-propagator/controllers/common"
 )
 
-const (
-	attemptsDefault = 3
-	attemptsEnvName = "CONTROLLER_CONFIG_RETRY_ATTEMPTS"
-)
-
-// The configuration in minutes to requeue after if something failed after several
-// retries.
-const (
-	requeueErrorDelayEnvName = "CONTROLLER_CONFIG_REQUEUE_ERROR_DELAY"
-	requeueErrorDelayDefault = 5
-)
-
 // The configuration of the maximum number of Go routines to spawn when handling placement decisions
 // per policy.
 const (
@@ -58,8 +46,6 @@ const (
 )
 
 var (
-	attempts             int
-	requeueErrorDelay    int
 	concurrencyPerPolicy int
 	kubeConfig           *rest.Config
 	kubeClient           *kubernetes.Interface
@@ -68,8 +54,6 @@ var (
 func Initialize(kubeconfig *rest.Config, kubeclient *kubernetes.Interface) {
 	kubeConfig = kubeconfig
 	kubeClient = kubeclient
-	attempts = getEnvVarPosInt(attemptsEnvName, attemptsDefault)
-	requeueErrorDelay = getEnvVarPosInt(requeueErrorDelayEnvName, requeueErrorDelayDefault)
 	concurrencyPerPolicy = getEnvVarPosInt(concurrencyPerPolicyEnvName, concurrencyPerPolicyDefault)
 }
 

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -268,7 +268,7 @@ func handleDecisionWrapper(
 			"policyNamespace", instance.GetNamespace(),
 			"decision", decision,
 		)
-		log.Info("Handling the decision")
+		log.V(1).Info("Handling the decision")
 
 		instanceCopy := *instance.DeepCopy()
 
@@ -530,15 +530,11 @@ func (r *PolicyReconciler) handleRootPolicy(instance *policiesv1.Policy) error {
 		return err
 	}
 
-	// allDecisions and failedClusters are sets in the format of <namespace>/<name>
 	placements, allDecisions, failedClusters, allFailed := r.handleDecisions(instance, pbList)
 	if allFailed {
 		log.Info("Failed to get any placement decisions. Giving up on the request.")
 
-		msg := "Could not get the placement decisions"
-
-		// Make the error start with a lower case for the linting check
-		return errors.New("c" + msg[1:])
+		return errors.New("could not get the placement decisions")
 	}
 
 	// Clean up before the status update in case the status update fails
@@ -761,6 +757,9 @@ func getPlacementDecisions(c client.Client, pb policiesv1.PlacementBinding,
 	return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
 }
 
+// handleDecision puts the policy on the cluster, creating it or updating it as required,
+// including resolving hub templates. It will return an error if an API call fails; no
+// internal states will result in errors (eg invalid templates don't cause errors here)
 func (r *PolicyReconciler) handleDecision(
 	rootPlc *policiesv1.Policy, decision appsv1.PlacementDecision,
 ) (

--- a/controllers/propagator/replication.go
+++ b/controllers/propagator/replication.go
@@ -37,6 +37,7 @@ func equivalentReplicatedPolicies(plc1 *policiesv1.Policy, plc2 *policiesv1.Poli
 // buildReplicatedPolicy constructs a replicated policy based on a root policy and a placementDecision.
 // In particular, it adds labels that the policy framework uses, and ensures that policy dependencies
 // are in a consistent format suited for use on managed clusters.
+// It can return an error if it needed to canonicalize a dependency, but a PolicySet lookup failed.
 func (r *PolicyReconciler) buildReplicatedPolicy(
 	root *policiesv1.Policy, decision appsv1.PlacementDecision,
 ) (*policiesv1.Policy, error) {

--- a/test/e2e/case6_placement_propagation_test.go
+++ b/test/e2e/case6_placement_propagation_test.go
@@ -21,8 +21,8 @@ const (
 )
 
 var _ = Describe("Test policy propagation", func() {
-	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update pb/plc", func() {
-		It("should be created in user ns", func() {
+	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update pb/plc", Ordered, func() {
+		BeforeAll(func() {
 			By("Creating " + case6PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case6PolicyYaml,
@@ -369,7 +369,7 @@ var _ = Describe("Test policy propagation", func() {
 			}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 		})
-		It("should clean up", func() {
+		AfterAll(func() {
 			utils.Kubectl("delete",
 				"-f", case6PolicyYaml,
 				"-n", testNamespace)
@@ -378,8 +378,8 @@ var _ = Describe("Test policy propagation", func() {
 		})
 	})
 
-	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update policy", func() {
-		It("should be created in user ns", func() {
+	Describe("Create policy/pb/plc in ns:"+testNamespace+" and then update policy", Ordered, func() {
+		BeforeAll(func() {
 			By("Creating " + case6PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case6PolicyYaml,
@@ -518,7 +518,7 @@ var _ = Describe("Test policy propagation", func() {
 				return replicatedPlc.Object["spec"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(yamlPlc.Object["spec"]))
 		})
-		It("should clean up", func() {
+		AfterAll(func() {
 			utils.Kubectl("delete",
 				"-f", "../resources/case6_placement_propagation/case6-test-policy2.yaml",
 				"-n", testNamespace)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -37,6 +37,7 @@ var (
 	gvrPlacementDecision  schema.GroupVersionResource
 	gvrSecret             schema.GroupVersionResource
 	gvrAnsibleJob         schema.GroupVersionResource
+	gvrNamespace          schema.GroupVersionResource
 	defaultTimeoutSeconds int
 	defaultImageRegistry  string
 )
@@ -78,6 +79,9 @@ var _ = BeforeSuite(func() {
 	}
 	gvrAnsibleJob = schema.GroupVersionResource{
 		Group: "tower.ansible.com", Version: "v1alpha1", Resource: "ansiblejobs",
+	}
+	gvrNamespace = schema.GroupVersionResource{
+		Group: "", Version: "v1", Resource: "namespaces",
 	}
 	clientHub = NewKubeClient("", "", "")
 	clientHubDynamic = NewKubeClientDynamic("", "", "")

--- a/test/resources/case6_placement_propagation/extra-cluster.yaml
+++ b/test/resources/case6_placement_propagation/extra-cluster.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test6-extra
+  finalizers:
+    - propagator-test.io/hold
+---
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: test6-extra
+    vendor: auto-detect
+  name: test6-extra
+spec: {}


### PR DESCRIPTION
The main change is to return an error when some clusters fail to be propagated to. The test verifies this works by using a cluster namespace that is Terminating during the propagation.

Also cleans up some random bits of code I noticed while working on this.

Refs:
 - https://issues.redhat.com/browse/ACM-4606