### PR TITLE
Fix hosted mode e2e test bug on GRC PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,13 @@ kind-deploy-controller: manifests
 	kubectl apply -f deploy/operator.yaml -n $(KIND_NAMESPACE)
 
 .PHONY: kind-deploy-controller-dev
-kind-deploy-controller-dev: kind-deploy-controller
+kind-deploy-controller-dev:
+	if [ "$(HOSTED)" -eq "hosted" ]; then\
+		export KIND_NAMESPACE=open-cluster-management;\
+	else\
+		$(MAKE) kind-deploy-controller;\
+	fi;
+	@echo KIND_NAMESPACE is $(KIND_NAMESPACE)
 	@echo Pushing image to KinD cluster
 	kind load docker-image $(REGISTRY)/$(IMG):$(TAG) --name $(KIND_NAME)
 	@echo "Patch deployment image"


### PR DESCRIPTION
reusable GitHub workflow for running the Kind E2E tests in hosted mode was added. We need to now trigger these tests from the component repos as part of the PR CI in releases 2.7+.

Modify the governance-policy-framework release-2.7, release-2.8, and main branches to consolidate this as a new job in the existing reusable workflow file.

Ref: https://issues.redhat.com/browse/ACM-5211