### PR TITLE
Change Error message namespace + policy names

### DIFF
--- a/api/v1/policy_webhook.go
+++ b/api/v1/policy_webhook.go
@@ -18,7 +18,7 @@ var (
 	// log is for logging in this package.
 	policylog = logf.Log.WithName("policy-validating-webhook")
 	errName   = errors.New("the combined length of the policy namespace and name " +
-		"<namespace>.<name> cannot exceed 63 characters")
+		"cannot exceed 62 characters")
 )
 
 func (r *Policy) SetupWebhookWithManager(mgr ctrl.Manager) error {

--- a/test/e2e/case17_policy_webhook_test.go
+++ b/test/e2e/case17_policy_webhook_test.go
@@ -21,8 +21,8 @@ const (
 	longNamesapce              string = "long-long-long-long-long-long-long"
 	case17PolicyReplicatedName string = "case17-test-policy-replicated-longlong"
 	errMsg                     string = `admission webhook "policy.open-cluster-management.io.webhook" denied the ` +
-		`request: the combined length of the policy namespace and name <namespace>.<name> ` +
-		`cannot exceed 63 characters`
+		`request: the combined length of the policy namespace and name ` +
+		`cannot exceed 62 characters`
 )
 
 var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {


### PR DESCRIPTION
Description: Change error message "the combined length of the policy namespace and name <namespace>.<name> cannot exceed 63 characters" to the combined length of the policy namespace and name <namespace>.<name> cannot exceed 62 characters
Ref: https://issues.redhat.com/browse/ACM-6838