### PR TITLE
Fix duplicated event generation when root policy is disabled

### DIFF
--- a/controllers/propagator/policy_controller.go
+++ b/controllers/propagator/policy_controller.go
@@ -124,7 +124,7 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 			// Owned objects are automatically garbage collected.
 			log.Info("Policy not found, so it may have been deleted. Deleting the replicated policies.")
 
-			err := r.cleanUpPolicy(&policiesv1.Policy{
+			_, err := r.cleanUpPolicy(&policiesv1.Policy{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       policiesv1.Kind,
 					APIVersion: policiesv1.GroupVersion.Group + "/" + policiesv1.GroupVersion.Version,


### PR DESCRIPTION
Currently the propagator performs a double reconcile when the root policy is disabled, which leads to duplicated events being created. The work-around to prevent the aforementioned duplicated events is to check for the existence of replicated policies in the managed cluster namespaces. When the root policy is disabled, the first reconcile will remove the replicated policies and on the second reconcile a new check is now added to determine the existence of replicated policies, which allow the controller to safely skip over the logic that emits the second duplicated event.

ref: https://issues.redhat.com/browse/ACM-6122