### PR TITLE
Fix 62 ns+name accepted error

### DIFF
--- a/api/v1/policy_webhook.go
+++ b/api/v1/policy_webhook.go
@@ -58,7 +58,7 @@ func (r *Policy) validateName() (admission.Warnings, error) {
 	}
 
 	// 1 character for "."
-	if (utf8.RuneCountInString(r.Name) + utf8.RuneCountInString(r.Namespace)) > 62 {
+	if (utf8.RuneCountInString(r.Name) + utf8.RuneCountInString(r.Namespace)) >= 62 {
 		return nil, errName
 	}
 

--- a/test/e2e/case17_policy_webhook_test.go
+++ b/test/e2e/case17_policy_webhook_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 		)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
-	Describe("Test name + namespace over 63", func() {
+	Describe("Test name + namespace is 62", func() {
 		It("Should the error message is presented", func() {
 			output, err := utils.KubectlWithOutput("apply",
 				"-f", case17PolicyLongYaml,

--- a/test/resources/case17_policy_webhook/case17_policy_long.yaml
+++ b/test/resources/case17_policy_webhook/case17_policy_long.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: case17-test-policy-long-long-long
+  name: case17-test-policy-long-long
 spec:
   remediationAction: inform
   disabled: false


### PR DESCRIPTION
Actual: namespace + name = 62 chars accepted.

Expect: Should be blocked with error message

Ref: https://issues.redhat.com/browse/ACM-7744