### PR TITLE
Ignore synced policies for hosted clusters

### DIFF
--- a/controllers/propagator/replicatedpolicy_controller.go
+++ b/controllers/propagator/replicatedpolicy_controller.go
@@ -346,12 +346,12 @@ func (r *ReplicatedPolicyReconciler) singleClusterDecision(
 	foundWithoutSubFilter := false
 
 	// Process all placement bindings without subFilter
-	for _, pb := range pbList.Items {
+	for i, pb := range pbList.Items {
 		if pb.SubFilter == policiesv1.Restricted {
 			continue
 		}
 
-		found, err := r.isSingleClusterInDecisions(ctx, &pb, rootPlc.GetName(), clusterName)
+		found, err := r.isSingleClusterInDecisions(ctx, &pbList.Items[i], rootPlc.GetName(), clusterName)
 		if err != nil {
 			return clusterDecision{}, err
 		}
@@ -376,12 +376,12 @@ func (r *ReplicatedPolicyReconciler) singleClusterDecision(
 	}
 
 	// Process all placement bindings with subFilter
-	for _, pb := range pbList.Items {
+	for i, pb := range pbList.Items {
 		if pb.SubFilter != policiesv1.Restricted {
 			continue
 		}
 
-		found, err := r.isSingleClusterInDecisions(ctx, &pb, rootPlc.GetName(), clusterName)
+		found, err := r.isSingleClusterInDecisions(ctx, &pbList.Items[i], rootPlc.GetName(), clusterName)
 		if err != nil {
 			return clusterDecision{}, err
 		}


### PR DESCRIPTION
Fixes issues noticed by [CI run in stolostron](https://github.com/stolostron/governance-policy-propagator/pull/459), but not here. In particular, an issue identified by SonarCloud, and an issue with hosted mode clusters.