### PR TITLE
[Hotfix]Filter replicated policy in rootstatus ctlr

### DIFF
--- a/controllers/rootpolicystatus/root_policy_status_controller.go
+++ b/controllers/rootpolicystatus/root_policy_status_controller.go
@@ -102,6 +102,11 @@ func (r *RootPolicyStatusReconciler) Reconcile(ctx context.Context, request ctrl
 		return reconcile.Result{}, err
 	}
 
+	// Replicated policies don't need to update status here
+	if _, ok := rootPolicy.Labels["policy.open-cluster-management.io/root-policy"]; ok {
+		return reconcile.Result{}, nil
+	}
+
 	_, err = common.RootStatusUpdate(ctx, r.Client, rootPolicy)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
When it is in hosted mode, root_status_controller loops because of the replicated policy.  replicated policies in hosted are not filtered because namespace is not in managedcluster. 