### PR TITLE
Run PolicyAutomation tests separately in CI

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -16,27 +16,15 @@ defaults:
     working-directory: governance-policy-propagator
 
 jobs:
-  kind-tests:
+  unit-tests:
     runs-on: ubuntu-latest
-    env:
-      REGISTRY: localhost:5000
-    strategy:
-      fail-fast: false
-      matrix:
-        # Run tests on minimum and newest supported OCP Kubernetes
-        # The "minimum" tag is set in the Makefile
-        # KinD tags: https://hub.docker.com/r/kindest/node/tags
-        kind:
-          - 'minimum'
-          - 'latest'
-    name: KinD tests
+    name: Unit Tests
     steps:
     - name: Checkout Governance Policy Propagator
       uses: actions/checkout@v3
       with:
         path: governance-policy-propagator
-        fetch-depth: 0 # Fetch all history for all tags and branches
-
+    
     - name: Set up Go
       uses: actions/setup-go@v3
       id: go
@@ -62,6 +50,38 @@ jobs:
       run: |
         make test
 
+    - name: Unit Test Coverage
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        make test-coverage
+    
+    - name: Upload Unit Test Coverage
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_unit
+        path: governance-policy-propagator/coverage_unit.out
+
+  kind-tests:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run tests on minimum and newest supported OCP Kubernetes
+        # The "minimum" tag is set in the Makefile
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'minimum'
+          - 'latest'
+    name: KinD tests
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+      with:
+        path: governance-policy-propagator
+
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:
         KIND_VERSION: ${{ matrix.kind }}
@@ -73,16 +93,24 @@ jobs:
         export GOPATH=$(go env GOPATH)
         make e2e-test-coverage
 
+    - name: Upload E2E Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_e2e
+        path: governance-policy-propagator/coverage_e2e.out
+
     - name: E2E Tests for Compliance Events API
       run: |
         make postgres
         make e2e-test-coverage-compliance-events-api
 
-    - name: Test Coverage Verification
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        make test-coverage
-        make coverage-verify
+    - name: Upload Compliance Events API Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_e2e_compliance_events_api
+        path: governance-policy-propagator/coverage_e2e_compliance_events_api.out
 
     - name: Verify Deployment Configuration
       run: |
@@ -103,4 +131,88 @@ jobs:
       if: ${{ always() }}
       run: |
         make kind-delete-cluster
-        
+
+  policyautomation-tests:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: localhost:5000
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run tests on minimum and newest supported OCP Kubernetes
+        # The "minimum" tag is set in the Makefile
+        # KinD tags: https://hub.docker.com/r/kindest/node/tags
+        kind:
+          - 'minimum'
+          - 'latest'
+    name: PolicyAutomation tests
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+      with:
+        path: governance-policy-propagator
+
+    - name: Create K8s KinD Cluster - ${{ matrix.kind }}
+      env:
+        KIND_VERSION: ${{ matrix.kind }}
+      run: |
+        make kind-bootstrap-cluster-dev
+
+    - name: PolicyAutomation E2E Tests
+      run: |
+        export GOPATH=$(go env GOPATH)
+        make e2e-test-coverage-policyautomation
+
+    - name: Upload PolicyAutomation Test Coverage
+      if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage_e2e_policyautomation
+        path: governance-policy-propagator/coverage_e2e_policyautomation.out
+
+    - name: Debug
+      if: ${{ failure() }}
+      run: |
+        make e2e-debug
+
+    - name: Clean up cluster
+      if: ${{ always() }}
+      run: |
+        make kind-delete-cluster
+
+  coveage-verification:
+    defaults:
+      run:
+        working-directory: '.'
+    runs-on: ubuntu-latest
+    name: Test Coverage Verification
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: [unit-tests, kind-tests, policyautomation-tests]
+
+    steps:
+    - name: Checkout Governance Policy Propagator
+      uses: actions/checkout@v3
+
+    - name: Download Unit Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_unit
+    
+    - name: Download E2E Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e
+
+    - name: Download Compliance Events Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e_compliance_events_api
+
+    - name: Download PolicyAutomation Coverage Result
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage_e2e_policyautomation
+    
+    - name: Test Coverage Verification
+      run: |
+        make coverage-verify

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -27,7 +27,7 @@ const (
 
 const automationName string = "create-service.now-ticket"
 
-var _ = Describe("Test policy automation", Ordered, func() {
+var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, func() {
 	ansiblelistlen := 0
 	// Use this only when target_clusters managed1 managed2 managed3
 	getLastAnsiblejob := func() *unstructured.Unstructured {


### PR DESCRIPTION
The PolicyAutomation tests were taking about half of the total e2e test duration. This excludes those tests from the usual `make e2e-test` target, which will accelerate both the CI and local development. Those tests are now run in a separate (concurrent) GH job in the CI workflow, and the test coverage information is merged in another new job.

This also combines the unit tests and linting tasks into one job, which means that a linting or formatting error will not prevent the e2e tests from running.

Refs:
 - https://issues.redhat.com/browse/ACM-8239