### PR TITLE
ACM-3299: governance-policy-propagator: Use SA for E2E

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -88,11 +88,15 @@ jobs:
         KIND_VERSION: ${{ matrix.kind }}
       run: |
         make kind-bootstrap-cluster-dev
+    
+    - name: Ensure Service Account kubeconfig
+      run: |
+        KUBECONFIG=${PWD}/kubeconfig_hub make kind-ensure-sa
 
     - name: E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-coverage
+        KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-coverage
 
     - name: Upload E2E Test Coverage
       if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
@@ -104,7 +108,7 @@ jobs:
     - name: E2E Tests for Compliance Events API
       run: |
         make postgres
-        make e2e-test-coverage-compliance-events-api
+        KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-coverage-compliance-events-api
 
     - name: Upload Compliance Events API Test Coverage
       if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}
@@ -117,11 +121,11 @@ jobs:
       run: |
         make webhook
         make build-images
-        make kind-deploy-controller-dev
+        KUBECONFIG=${PWD}/kubeconfig_hub_e2e make kind-deploy-controller-dev
     
     - name: E2E Tests for Webhook
       run: |
-        make e2e-test-webhook
+        KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-webhook
 
     - name: Debug
       if: ${{ failure() }}
@@ -162,7 +166,7 @@ jobs:
     - name: PolicyAutomation E2E Tests
       run: |
         export GOPATH=$(go env GOPATH)
-        make e2e-test-coverage-policyautomation
+        KUBECONFIG=${PWD}/kubeconfig_hub make e2e-test-coverage-policyautomation
 
     - name: Upload PolicyAutomation Test Coverage
       if: ${{ github.event_name == 'pull_request' && matrix.kind == 'latest'}}

--- a/deploy/manager/kustomization.yaml
+++ b/deploy/manager/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
 - ./manager.yaml
+- ./service-account.yaml
 - ../rbac/

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -59,35 +59,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: propagator-webhook-server-cert
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: governance-policy-propagator-global
-subjects:
-- kind: ServiceAccount
-  name: governance-policy-propagator
-  namespace: open-cluster-management
-roleRef:
-  kind: ClusterRole
-  name: governance-policy-propagator
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: governance-policy-propagator-leader-election-rolebinding
-subjects:
-- kind: ServiceAccount
-  name: governance-policy-propagator
-  namespace: open-cluster-management
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: governance-policy-propagator-leader-election-role
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: governance-policy-propagator
-  namespace: open-cluster-management

--- a/deploy/manager/service-account.yaml
+++ b/deploy/manager/service-account.yaml
@@ -1,0 +1,32 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: governance-policy-propagator-global
+subjects:
+- kind: ServiceAccount
+  name: governance-policy-propagator
+  namespace: open-cluster-management
+roleRef:
+  kind: ClusterRole
+  name: governance-policy-propagator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: governance-policy-propagator-leader-election-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: governance-policy-propagator
+  namespace: open-cluster-management
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: governance-policy-propagator-leader-election-role
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: governance-policy-propagator
+  namespace: open-cluster-management

--- a/test/e2e/case10_policyset_propagation_test.go
+++ b/test/e2e/case10_policyset_propagation_test.go
@@ -33,7 +33,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -150,7 +151,8 @@ var _ = Describe("Test policyset propagation", func() {
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting policyset")
-			_, err := utils.KubectlWithOutput("delete", "policyset", case10PolicySetName, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("delete", "policyset",
+				case10PolicySetName, "-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -165,7 +167,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -191,7 +194,7 @@ var _ = Describe("Test policyset propagation", func() {
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting placementbinding")
 			_, err := utils.KubectlWithOutput("delete", "PlacementBinding", case10PolicySetName+"-pb", "-n",
-				testNamespace)
+				testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			opt := metav1.ListOptions{
 				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
@@ -202,7 +205,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -228,7 +232,7 @@ var _ = Describe("Test policyset propagation", func() {
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting placementrule")
 			_, err := utils.KubectlWithOutput("delete", "PlacementRule", case10PolicySetName+"-plr", "-n",
-				testNamespace)
+				testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			opt := metav1.ListOptions{
 				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
@@ -239,7 +243,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -266,7 +271,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -284,7 +290,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -384,7 +391,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetPolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -402,7 +410,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetPlacementYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -479,7 +488,8 @@ var _ = Describe("Test policyset propagation", func() {
 		})
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting policyset")
-			_, err := utils.KubectlWithOutput("delete", "policyset", case10PolicySetName, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("delete", "policyset", case10PolicySetName,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -494,7 +504,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetPlacementYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -530,7 +541,7 @@ var _ = Describe("Test policyset propagation", func() {
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting placementbinding")
 			_, err := utils.KubectlWithOutput("delete", "PlacementBinding", case10PolicySetName+"-pb", "-n",
-				testNamespace)
+				testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			opt := metav1.ListOptions{
 				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
@@ -541,7 +552,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetPlacementYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -577,7 +589,7 @@ var _ = Describe("Test policyset propagation", func() {
 		It("should remove policy from ns managed1 and managed2", func() {
 			By("Deleting placementDecision")
 			_, err := utils.KubectlWithOutput("delete", "PlacementDecision", case10PolicySetName+"-plm-decision", "-n",
-				testNamespace)
+				testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			opt := metav1.ListOptions{
 				LabelSelector: common.RootPolicyLabel + "=" + testNamespace + "." + case10PolicyName,
@@ -588,7 +600,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetPlacementYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -599,7 +612,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetPlacementYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -617,7 +631,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetPolicyPlacementYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPolicyPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -675,7 +690,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetPolicyPlacementYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetPolicyPlacementYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -693,7 +709,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetPolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, true, defaultTimeoutSeconds,
@@ -809,7 +826,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetPolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName, testNamespace, false, defaultTimeoutSeconds,
@@ -828,7 +846,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetMultipleYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetMultipleYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, true, defaultTimeoutSeconds,
@@ -886,7 +905,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetMultipleYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetMultipleYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, false, defaultTimeoutSeconds,
@@ -909,7 +929,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetMultipleSinglePBYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetMultipleSinglePBYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, true, defaultTimeoutSeconds,
@@ -1059,7 +1080,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetMultipleSinglePBYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetMultipleSinglePBYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, false, defaultTimeoutSeconds,
@@ -1082,7 +1104,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Creating " + case10PolicySetMultipleSinglePBYaml)
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case10PolicySetMultipleSinglePBYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, true, defaultTimeoutSeconds,
@@ -1118,7 +1141,8 @@ var _ = Describe("Test policyset propagation", func() {
 			By("Deleting " + case10PolicySetMultipleSinglePBYaml)
 			_, err := utils.KubectlWithOutput("delete",
 				"-f", case10PolicySetMultipleSinglePBYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 			plcSet1 := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case10PolicySetName+"1", testNamespace, false, defaultTimeoutSeconds,

--- a/test/e2e/case11_policyset_controller_test.go
+++ b/test/e2e/case11_policyset_controller_test.go
@@ -40,7 +40,8 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case11PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case11PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -58,7 +59,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			Expect(err).ToNot(HaveOccurred())
 			plc = utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, testNamespace+"."+case11PolicyName, "managed2", true,
-				defaultTimeoutSeconds,
+				60,
 			)
 			Expect(plc).ToNot(BeNil())
 
@@ -102,7 +103,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicySetPatchYaml)
 			utils.Kubectl("apply",
 				"-f", case11PolicySetPatchYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case11PolicySetName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -120,7 +121,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 				"apply",
 				"-f",
 				"../resources/case11_policyset_controller/case11-reset-plcset.yaml", "-n",
-				testNamespace,
+				testNamespace, "--kubeconfig="+kubeconfigHub,
 			)
 		})
 		It("should update to compliant if all its child policy violations have been remediated", func() {
@@ -193,7 +194,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11DisablePolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case11DisablePolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case11PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -212,7 +213,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicyCompliantYaml)
 			utils.Kubectl("apply",
 				"-f", case11PolicyCompliantYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plc = utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case11PolicyCompliant, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -220,7 +221,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 
 			utils.Kubectl("apply",
 				"-f", case11PolicySetPatch2Yaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case11PolicySetName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -279,10 +280,10 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicyManaged2Yaml)
 			utils.Kubectl("apply",
 				"-f", case11PolicySetManaged1Yaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("apply",
 				"-f", case11PolicyManaged2Yaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case11PolicyNameManaged2, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -362,7 +363,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicySetEmpty)
 			utils.Kubectl("apply",
 				"-f", case11PolicySetEmptyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case11PolicySetEmpty, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -380,7 +381,7 @@ var _ = Describe("Test policyset controller status updates", func() {
 			By("Creating " + case11PolicySetMultiStatus)
 			utils.Kubectl("apply",
 				"-f", case11PolicySetMultiStatusYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plcSet := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicySet, case11PolicySetMultiStatus, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -399,22 +400,22 @@ var _ = Describe("Test policyset controller status updates", func() {
 		It("should clean up", func() {
 			utils.Kubectl("delete",
 				"-f", "../resources/case11_policyset_controller/case11-test-policy.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", "../resources/case11_policyset_controller/case11-empty-plcset.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case11PolicySetManaged1Yaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case11PolicyManaged2Yaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case11PolicyCompliantYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case11PolicySetMultiStatusYaml,
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, defaultTimeoutSeconds)
 		})

--- a/test/e2e/case12_encryptionkeys_controller_test.go
+++ b/test/e2e/case12_encryptionkeys_controller_test.go
@@ -41,13 +41,15 @@ var _ = Describe("Test policy encryption key rotation", func() {
 
 	It("should create some sample policies", func() {
 		By("Creating the root policies with placement rules and bindings")
-		utils.Kubectl("apply", "-f", policyOneYaml, "-n", testNamespace)
+		utils.Kubectl("apply", "-f", policyOneYaml,
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 		rootOne := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, policyOneName, testNamespace, true, defaultTimeoutSeconds,
 		)
 		Expect(rootOne).NotTo(BeNil())
 
-		utils.Kubectl("apply", "-f", policyTwoYaml, "-n", testNamespace)
+		utils.Kubectl("apply", "-f", policyTwoYaml,
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 		rootTwo := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, policyTwoName, testNamespace, true, defaultTimeoutSeconds,
 		)
@@ -90,7 +92,8 @@ var _ = Describe("Test policy encryption key rotation", func() {
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 1, true, defaultTimeoutSeconds)
 
 		By("Adding the IV Annotation to the replicated policy-one")
-		utils.Kubectl("apply", "-n", "managed1", "-f", replicatedPolicyOneYaml)
+		utils.Kubectl("apply", "-n", "managed1",
+			"-f", replicatedPolicyOneYaml, "--kubeconfig="+kubeconfigHub)
 
 		Eventually(func() interface{} {
 			replicatedPolicy := utils.GetWithTimeout(

--- a/test/e2e/case13_policyset_dependencies_test.go
+++ b/test/e2e/case13_policyset_dependencies_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 	setup := func() {
 		By("Creating the policy, policyset, binding, and rule")
-		utils.Kubectl("apply", "-f", case13PolicyYaml, "-n", testNamespace)
+		utils.Kubectl("apply", "-f", case13PolicyYaml, "-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 		rootplc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case13PolicyName, testNamespace, true, defaultTimeoutSeconds,
 		)
@@ -59,8 +59,8 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 		DeferCleanup(func() {
 			By("Running cleanup")
-			utils.Kubectl("delete", "-f", case13PolicyYaml, "-n", testNamespace)
-			utils.Kubectl("delete", "-f", case13Set2Yaml)
+			utils.Kubectl("delete", "-f", case13PolicyYaml, "-n", testNamespace, "--kubeconfig="+kubeconfigHub)
+			utils.Kubectl("delete", "-f", case13Set2Yaml, "--kubeconfig="+kubeconfigHub)
 			time.Sleep(5 * time.Second) // this helps everything get cleaned up completely
 		})
 	}
@@ -100,7 +100,8 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 		It("should replace a PolicySet dependency with each policy in the existing set", func() {
 			By("Updating the root policy to have a PolicySet dependency")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Test1Yaml, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test1Yaml,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of dependencies")
@@ -112,7 +113,8 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 		It("should keep a non-existent PolicySet dependency as-is", func() {
 			By("Updating the root policy to have a non-existent PolicySet dependency")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Test2Yaml, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test2Yaml,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of dependencies")
@@ -130,7 +132,7 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 			time.Sleep(5 * time.Second)
 
 			By("Creating the PolicySet that was non-existent")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of dependencies")
@@ -149,7 +151,7 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 			time.Sleep(5 * time.Second)
 
 			By("Updating the PolicySet")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of dependencies")
@@ -205,7 +207,8 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 		It("should replace a PolicySet extraDependency with each policy in the existing set", func() {
 			By("Updating the root policy to have a PolicySet extraDependency")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Test3Yaml, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test3Yaml,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of extraDependencies")
@@ -217,7 +220,8 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 
 		It("should keep a non-existent PolicySet extraDependency as-is", func() {
 			By("Updating the root policy to have a non-existent PolicySet dependency")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Test4Yaml, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Test4Yaml,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of extraDependencies")
@@ -235,7 +239,7 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 			time.Sleep(5 * time.Second)
 
 			By("Creating the PolicySet that was non-existent")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2Yaml, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of extraDependencies")
@@ -254,7 +258,7 @@ var _ = Describe("Test replacement of policysets in dependencies", Ordered, func
 			time.Sleep(5 * time.Second)
 
 			By("Updating the PolicySet")
-			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml)
+			_, err := utils.KubectlWithOutput("apply", "-f", case13Set2updateYaml, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking that the replicated policy has the correct list of dependencies")

--- a/test/e2e/case14_root_policy_metrics_test.go
+++ b/test/e2e/case14_root_policy_metrics_test.go
@@ -38,7 +38,8 @@ var _ = Describe("Test root policy metrics", Ordered, func() {
 			By("Creating " + policyYaml)
 			utils.Kubectl("apply",
 				"-f", policyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, policyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -104,7 +105,8 @@ var _ = Describe("Test root policy metrics", Ordered, func() {
 		cleanup := func() {
 			utils.Kubectl("delete",
 				"-f", policyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, defaultTimeoutSeconds)
 		}

--- a/test/e2e/case16_selective_policy_enforcement_test.go
+++ b/test/e2e/case16_selective_policy_enforcement_test.go
@@ -23,7 +23,8 @@ var _ = Describe("Test selective policy enforcement", Ordered, func() {
 
 	BeforeAll(func() {
 		By("Creating the test policy, the initial placement binding, and placement rule")
-		_, err := utils.KubectlWithOutput("apply", "-f", case16PolicyYaml, "-n", testNamespace)
+		_, err := utils.KubectlWithOutput("apply", "-f", case16PolicyYaml,
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 		Expect(err).ToNot(HaveOccurred())
 		rootplc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case16PolicyName, testNamespace, true, defaultTimeoutSeconds,
@@ -53,16 +54,19 @@ var _ = Describe("Test selective policy enforcement", Ordered, func() {
 
 	AfterAll(func() {
 		By("Cleaning up resources")
-		_, err := utils.KubectlWithOutput("delete", "-f", case16PolicyYaml, "-n", testNamespace, "--ignore-not-found")
+		_, err := utils.KubectlWithOutput("delete", "-f", case16PolicyYaml,
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub, "--ignore-not-found")
 		Expect(err).ToNot(HaveOccurred())
-		_, err = utils.KubectlWithOutput("delete", "-f", case16BindingYaml, "-n", testNamespace, "--ignore-not-found")
+		_, err = utils.KubectlWithOutput("delete", "-f", case16BindingYaml,
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub, "--ignore-not-found")
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("Testing enforcing with subFilter", Ordered, func() {
 		It("should update the policy's remediationAction to enforce on cluster ns managed1, managed2", func() {
 			By("Creating another placement rule and binding to selectively enforce policy")
-			_, err := utils.KubectlWithOutput("apply", "-f", case16BindingYaml, "-n", testNamespace)
+			_, err := utils.KubectlWithOutput("apply", "-f", case16BindingYaml,
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Patching the case16-test-policy-plr-enforce with decisions managed1, managed2, managed3")
@@ -215,7 +219,7 @@ var _ = Describe("Test selective policy enforcement", Ordered, func() {
 
 			By("Removing the subfilter from the binding")
 			utils.Kubectl("patch", "placementbinding", "case16-test-policy-pb-enforce", "-n", testNamespace,
-				"--type=json", `-p=[{"op":"remove","path":"/subFilter"}]`)
+				"--kubeconfig="+kubeconfigHub, "--type=json", `-p=[{"op":"remove","path":"/subFilter"}]`)
 
 			By("Verifying the policies exist and are enforcing on all 3 clusters")
 			for _, clustername := range []string{"managed1", "managed2", "managed3"} {
@@ -233,7 +237,7 @@ var _ = Describe("Test selective policy enforcement", Ordered, func() {
 		It("should change remediationAction when the bindingOverrides are removed", func() {
 			By("Removing the overrides from the binding")
 			utils.Kubectl("patch", "placementbinding", "case16-test-policy-pb-enforce", "-n", testNamespace,
-				"--type=json", `-p=[{"op":"remove","path":"/bindingOverrides"}]`)
+				"--kubeconfig="+kubeconfigHub, "--type=json", `-p=[{"op":"remove","path":"/bindingOverrides"}]`)
 
 			By("Verifying the policies are informing on all 3 clusters")
 			for _, clustername := range []string{"managed1", "managed2", "managed3"} {

--- a/test/e2e/case17_policy_webhook_test.go
+++ b/test/e2e/case17_policy_webhook_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 	Describe("Test name + namespace over 63", func() {
 		BeforeAll(func() {
 			_, err := utils.KubectlWithOutput("create",
-				"ns", longNamespace,
+				"ns", longNamespace, "--kubeconfig="+kubeconfigHub,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -48,6 +48,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			// cleanup
 			_, err := utils.KubectlWithOutput("delete",
 				"ns", longNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -55,6 +56,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err = utils.KubectlWithOutput("delete",
 				"policy", case17PolicyReplicatedName,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -62,6 +64,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err = utils.KubectlWithOutput("delete",
 				"placementrule", case17PolicyReplicatedPlr,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -69,6 +72,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err = utils.KubectlWithOutput("delete",
 				"placementbinding", case17PolicyReplicatedPb,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -76,14 +80,16 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 		It("Should the error message is presented", func() {
 			output, err := utils.KubectlWithOutput("apply",
 				"-f", case17PolicyLongYaml,
-				"-n", longNamespace)
+				"-n", longNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).Should(HaveOccurred())
 			Expect(output).Should(ContainSubstring(combinedLengthErr))
 		})
 		It("Should replicated policy should not be validated", func() {
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case17PolicyReplicatedYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 			plr := utils.GetWithTimeout(
 				clientHubDynamic, gvrPlacementRule, case17PolicyReplicatedName+"-plr",
@@ -113,6 +119,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err := utils.KubectlWithOutput("delete",
 				"policy", case17PolicyRemediationName,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -120,6 +127,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err = utils.KubectlWithOutput("delete",
 				"policy", case17PolicyRootRemediationName,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -127,6 +135,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			_, err = utils.KubectlWithOutput("delete",
 				"policy", case17PolicyCfplcRemediationName,
 				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--ignore-not-found",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -137,7 +146,8 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 				"and the configuration policy in the policy templates are unset")
 			output, err := utils.KubectlWithOutput("apply",
 				"-f", case17PolicyRemediationYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).Should(HaveOccurred())
 			Expect(output).Should(ContainSubstring(remediationErr))
 		})
@@ -147,14 +157,16 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 				"root policy is set")
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", case17PolicyRootRemediationYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Applying a policy where only the remediationAction of the " +
 				"configuration policy in the policy templates is set")
 			_, err = utils.KubectlWithOutput("apply",
 				"-f", case17PolicyCfplcRemediationYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
@@ -164,6 +176,7 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 
 			output, err := utils.KubectlWithOutput("patch", "policy",
 				case17PolicyRootRemediationName, "-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub,
 				"--type=json", "-p", "[{'op': 'remove', 'path': '/spec/remediationAction'}]",
 			)
 
@@ -175,7 +188,8 @@ var _ = Describe("Test policy webhook", Label("webhook"), Ordered, func() {
 			By("Patching a policy so that only the remediationAction field of the root policy is unset")
 
 			_, err := utils.KubectlWithOutput("patch", "policy",
-				case17PolicyRootRemediationName, "-n", testNamespace, "--type=json", "-p",
+				case17PolicyRootRemediationName, "-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub, "--type=json", "-p",
 				"[{'op': 'add', 'path': '/spec/remediationAction', 'value': 'inform'}]",
 			)
 

--- a/test/e2e/case19_rep_policy_placement_test.go
+++ b/test/e2e/case19_rep_policy_placement_test.go
@@ -21,7 +21,8 @@ var _ = Describe("Test replicated_policy controller and propagation", Ordered, S
 		By("Creating " + case19PolicyName)
 		utils.Kubectl("apply",
 			"-f", case19PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub)
 		plc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case19PolicyName, testNamespace, true, defaultTimeoutSeconds,
 		)
@@ -31,7 +32,9 @@ var _ = Describe("Test replicated_policy controller and propagation", Ordered, S
 		By("Creating " + case19PolicyName)
 		utils.Kubectl("delete",
 			"-f", case19PolicyYaml,
-			"-n", testNamespace, "--ignore-not-found")
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub,
+			"--ignore-not-found")
 		plc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case19PolicyName, testNamespace, false, defaultTimeoutSeconds,
 		)

--- a/test/e2e/case1_propagation_test.go
+++ b/test/e2e/case1_propagation_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test policy propagation", func() {
 	Describe("Test event emission when policy is disabled", Ordered, func() {
 		BeforeAll(func() {
 			By("Creating the policy, placementrule, and placementbinding")
-			utils.Kubectl("apply", "-f", case1PolicyYaml, "-n", testNamespace)
+			utils.Kubectl("apply", "-f", case1PolicyYaml, "-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -118,7 +118,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case1PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -437,7 +438,8 @@ var _ = Describe("Test policy propagation", func() {
 		It("should clean up", func() {
 			utils.Kubectl("delete",
 				"-f", case1PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		})
@@ -448,7 +450,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case1PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -520,7 +523,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case1PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case1PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -549,7 +553,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating ../resources/case1_propagation/case1-test-policy2.yaml")
 			utils.Kubectl("apply",
 				"-f", "../resources/case1_propagation/case1-test-policy2.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			rootPlc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case1PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -621,7 +626,7 @@ var _ = Describe("Test policy propagation", func() {
 		It("should clean up", func() {
 			utils.Kubectl("delete",
 				"-f", "../resources/case1_propagation/case1-test-policy2.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		})

--- a/test/e2e/case2_aggregation_test.go
+++ b/test/e2e/case2_aggregation_test.go
@@ -26,7 +26,8 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Creating " + case2PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case2PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -121,7 +122,7 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Creating pb-plr-2 to binding second set of placement")
 			utils.Kubectl("apply",
 				"-f", "../resources/case2_aggregation/pb-plr-2.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-single-status.yaml")
 			Eventually(func() interface{} {
@@ -176,7 +177,7 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Remove" + case2PolicyName + "-plr")
 			utils.Kubectl("delete",
 				"placementrule", case2PolicyName+"-plr",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placement-status-missing-plr.yaml")
 			Eventually(func() interface{} {
@@ -191,7 +192,7 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Remove" + case2PolicyName + "-plr2")
 			utils.Kubectl("delete",
 				"placementrule", case2PolicyName+"-plr2",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Checking the status of root policy")
 			yamlPlc := utils.ParseYaml("../resources/case2_aggregation/managed-both-placementbinding.yaml")
 			Eventually(func() interface{} {
@@ -206,10 +207,10 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Remove" + case2PolicyName + "-pb and " + case2PolicyName + "-pb2")
 			utils.Kubectl("delete",
 				"placementbinding", case2PolicyName+"-pb",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"placementbinding", case2PolicyName+"-pb2",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			By("Checking the status of root policy")
 			emptyStatus := map[string]interface{}{}
 			Eventually(func() interface{} {
@@ -223,7 +224,8 @@ var _ = Describe("Test policy status aggregation", func() {
 		It("should clean up", func() {
 			utils.Kubectl("delete",
 				"-f", case2PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		})
@@ -240,7 +242,8 @@ var _ = Describe("Test policy status aggregation", func() {
 			By("Creating " + case2PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case2PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case2PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -264,7 +267,7 @@ var _ = Describe("Test policy status aggregation", func() {
 
 		AfterAll(func() {
 			By("Cleaning up")
-			utils.Kubectl("delete", "-f", case2PolicyYaml, "-n", testNamespace)
+			utils.Kubectl("delete", "-f", case2PolicyYaml, "-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, false, 10)
 		})
 

--- a/test/e2e/case3_mutation_recovery_test.go
+++ b/test/e2e/case3_mutation_recovery_test.go
@@ -26,7 +26,8 @@ var _ = Describe("Test unexpected policy mutation", func() {
 		By("Creating " + case3PolicyYaml)
 		utils.Kubectl("apply",
 			"-f", case3PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub)
 		plc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case3PolicyName, testNamespace, true, defaultTimeoutSeconds,
 		)
@@ -65,14 +66,15 @@ var _ = Describe("Test unexpected policy mutation", func() {
 	AfterEach(func() {
 		utils.Kubectl("delete",
 			"-f", case3PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub)
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, true, defaultTimeoutSeconds)
 	})
 	It("Should recreate replicated policy when deleted", func() {
 		By("Deleting policy in cluster ns")
-		utils.Kubectl("delete", "policy", "-n", "managed1", "--all")
-		utils.Kubectl("delete", "policy", "-n", "managed2", "--all")
+		utils.Kubectl("delete", "policy", "-n", "managed1", "--all", "--kubeconfig="+kubeconfigHub)
+		utils.Kubectl("delete", "policy", "-n", "managed2", "--all", "--kubeconfig="+kubeconfigHub)
 		By("Checking number of policy left in all ns")
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 3, true, defaultTimeoutSeconds)

--- a/test/e2e/case4_unexpected_policy_test.go
+++ b/test/e2e/case4_unexpected_policy_test.go
@@ -21,7 +21,8 @@ var _ = Describe("Test unexpect policy handling", func() {
 		By("Creating " + case4PolicyYaml + "in cluster namespace: managed1")
 		out, err := utils.KubectlWithOutput("apply",
 			"-f", case4PolicyYaml,
-			"-n", "managed1")
+			"-n", "managed1",
+			"--kubeconfig="+kubeconfigHub)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).Should(ContainSubstring(case4PolicyName + " created"))
 		Eventually(func() interface{} {
@@ -35,7 +36,8 @@ var _ = Describe("Test unexpect policy handling", func() {
 		By("Creating " + plcYaml + " in cluster namespace: managed1")
 		out, err := utils.KubectlWithOutput("apply",
 			"-f", plcYaml,
-			"-n", "managed1")
+			"-n", "managed1",
+			"--kubeconfig="+kubeconfigHub)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).Should(ContainSubstring("policy-propagator-test.case4-test-policy created"))
 		Eventually(func() interface{} {
@@ -54,7 +56,8 @@ var _ = Describe("Test unexpect policy handling", func() {
 		By("Creating " + plcYaml + " in non-cluster namespace: leaf-hub1")
 		out, err := utils.KubectlWithOutput("apply",
 			"-f", plcYaml,
-			"-n", "leaf-hub1")
+			"-n", "leaf-hub1",
+			"--kubeconfig="+kubeconfigHub)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(out).Should(ContainSubstring("policy-propagator-test.case4-test-policy created"))
 		utils.Pause(2)
@@ -67,7 +70,7 @@ var _ = Describe("Test unexpect policy handling", func() {
 	It("should clean up the non-cluster policy", func() {
 		utils.Kubectl("delete",
 			"-f", "../resources/case4_unexpected_policy/case4-test-replicated-policy-out-of-cluster.yaml",
-			"-n", "leaf-hub1")
+			"-n", "leaf-hub1", "--kubeconfig="+kubeconfigHub)
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, metav1.ListOptions{}, 0, false, 10)
 	})
 })

--- a/test/e2e/case5_policy_automation_test.go
+++ b/test/e2e/case5_policy_automation_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 		By("Creating " + case5PolicyName + " in user ns")
 		_, err := utils.KubectlWithOutput("apply",
 			"-f", case5PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 		Expect(err).ShouldNot(HaveOccurred())
 		plc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case5PolicyName, testNamespace, true, defaultTimeoutSeconds,
@@ -121,7 +121,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 	cleanupPolicyAutomation := func() {
 		By("Removing config map")
 		_, err := utils.KubectlWithOutput(
-			"delete", "policyautomation", "-n", testNamespace, automationName,
+			"delete", "policyautomation", "-n", testNamespace, automationName, "--kubeconfig="+kubeconfigHub,
 			"--ignore-not-found",
 		)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -171,7 +171,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 			By("Creating an policyAutomation with mode=disable")
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", "../resources/case5_policy_automation/case5-policy-automation-disable.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 			By("Should not create any ansiblejob when mode = disable")
 			Consistently(func() interface{} {
@@ -254,7 +254,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -264,7 +265,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 				index := len(ansiblejobList.Items) - 1
 				spec := ansiblejobList.Items[index].Object["spec"]
@@ -332,7 +334,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -370,7 +373,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 
 			By("Removing config map")
 			_, err = utils.KubectlWithOutput(
-				"delete", "policyautomation", "-n", testNamespace, automationName,
+				"delete", "policyautomation", "-n", testNamespace, automationName, "--kubeconfig="+kubeconfigHub,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			By("Ansiblejob should also be removed")
@@ -389,7 +392,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 			By("Creating an policyAutomation with mode=everyEvent")
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", "../resources/case5_policy_automation/case5-policy-automation-everyEvent.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Should not create any new ansiblejob when Compliant")
@@ -438,7 +441,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -449,7 +453,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -555,7 +560,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// This ansiblelistlen is the length created before changed to noncompliant
@@ -571,7 +577,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 			By("Creating an policyAutomation with mode=everyEvent")
 			_, err := utils.KubectlWithOutput("apply",
 				"-f", "../resources/case5_policy_automation/case5-policy-automation-everyEvent.yaml",
-				"-n", testNamespace)
+				"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 			Expect(err).ShouldNot(HaveOccurred())
 
 			By("Patching everyEvent mode policyAutomation with delayAfterRunSeconds = 240")
@@ -634,7 +640,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 			By("checking the last AnsibleJob has managed3 in target_clsuter for" +
 				"the first event during delayAfterRunSeconds period")
 			Eventually(func() interface{} {
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return getLastJobCompliant()
@@ -646,7 +653,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 				// Save ansiblelistlen for next test
 				ansiblelistlen = len(ansiblejobList.Items)
@@ -830,7 +838,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -841,7 +850,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					context.TODO(), metav1.ListOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+				_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+					testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				return len(ansiblejobList.Items)
@@ -849,7 +859,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 
 			By("Removing config map")
 			_, err = utils.KubectlWithOutput(
-				"delete", "policyautomation", "-n", testNamespace, automationName,
+				"delete", "policyautomation", "-n", testNamespace, automationName, "--kubeconfig="+kubeconfigHub,
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			By("Ansiblejob should also be removed")
@@ -914,6 +924,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					automationName,
 					"--overwrite",
 					"policy.open-cluster-management.io/rerun=true",
+					"--kubeconfig="+kubeconfigHub,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
@@ -923,7 +934,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 						context.TODO(), metav1.ListOptions{},
 					)
 					Expect(err).ToNot(HaveOccurred())
-					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+						testNamespace, "--kubeconfig="+kubeconfigHub)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(ansiblejobList.Items)
@@ -933,7 +945,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 						context.TODO(), metav1.ListOptions{},
 					)
 					Expect(err).ShouldNot(HaveOccurred())
-					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+						testNamespace, "--kubeconfig="+kubeconfigHub)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return getTargetListlen(ansiblejobList)
@@ -986,6 +999,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					automationName,
 					"--overwrite",
 					"policy.open-cluster-management.io/rerun=true",
+					"--kubeconfig="+kubeconfigHub,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 				By("Should still create one more ansiblejob when policy is Compliant")
@@ -994,7 +1008,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 						context.TODO(), metav1.ListOptions{},
 					)
 					Expect(err).ToNot(HaveOccurred())
-					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+						testNamespace, "--kubeconfig="+kubeconfigHub)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(ansiblejobList.Items)
@@ -1004,7 +1019,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 						context.TODO(), metav1.ListOptions{},
 					)
 					Expect(err).ToNot(HaveOccurred())
-					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n", testNamespace)
+					_, err = utils.KubectlWithOutput("get", "ansiblejobs", "-n",
+						testNamespace, "--kubeconfig="+kubeconfigHub)
 					Expect(err).ShouldNot(HaveOccurred())
 
 					return len(ansiblejobList.Items)
@@ -1041,7 +1057,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 				By("Creating an policyAutomation with mode=disable")
 				_, err = utils.KubectlWithOutput("apply",
 					"-f", "../resources/case5_policy_automation/case5-policy-automation-disable.yaml",
-					"-n", testNamespace)
+					"-n", testNamespace, "--kubeconfig="+kubeconfigHub)
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 			It("Should no issue when policy set to disabled = true ", func() {
@@ -1054,6 +1070,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					automationName,
 					"--overwrite",
 					"policy.open-cluster-management.io/rerun=true",
+					"--kubeconfig="+kubeconfigHub,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -1089,6 +1106,7 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 					automationName,
 					"--overwrite",
 					"policy.open-cluster-management.io/rerun=true",
+					"--kubeconfig="+kubeconfigHub,
 				)
 				Expect(err).ShouldNot(HaveOccurred())
 
@@ -1109,7 +1127,8 @@ var _ = Describe("Test policy automation", Label("policyautomation"), Ordered, f
 
 	AfterAll(func() {
 		By("Removing policy")
-		_, err := utils.KubectlWithOutput("delete", "policy", "-n", testNamespace, case5PolicyName)
+		_, err := utils.KubectlWithOutput("delete", "policy", "-n",
+			testNamespace, case5PolicyName, "--kubeconfig="+kubeconfigHub)
 		Expect(err).ToNot(HaveOccurred())
 		By("PolicyAutomation should also be removed")
 		Eventually(func() *unstructured.Unstructured {

--- a/test/e2e/case7_bindings_test.go
+++ b/test/e2e/case7_bindings_test.go
@@ -30,7 +30,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case7PolicyYaml)
 			utils.Kubectl("apply",
 				"-f", case7PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			plc := utils.GetWithTimeout(
 				clientHubDynamic, gvrPolicy, case7PolicyName, testNamespace, true, defaultTimeoutSeconds,
 			)
@@ -38,7 +39,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case7BindingYaml1)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml1,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			binding := utils.GetWithTimeout(
 				clientHubDynamic,
 				gvrPlacementBinding,
@@ -51,7 +53,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case7BindingYaml2)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml2,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			binding = utils.GetWithTimeout(
 				clientHubDynamic,
 				gvrPlacementBinding,
@@ -64,7 +67,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case7BindingYaml3)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml3,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			binding = utils.GetWithTimeout(
 				clientHubDynamic,
 				gvrPlacementBinding,
@@ -77,7 +81,8 @@ var _ = Describe("Test policy propagation", func() {
 			By("Creating " + case7BindingYaml4)
 			utils.Kubectl("apply",
 				"-f", case7BindingYaml4,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			binding = utils.GetWithTimeout(
 				clientHubDynamic,
 				gvrPlacementBinding,
@@ -218,21 +223,26 @@ var _ = Describe("Test policy propagation", func() {
 			By("Clean up")
 			utils.Kubectl("delete",
 				"-f", case7PolicyYaml,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			opt := metav1.ListOptions{}
 			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 			utils.Kubectl("delete",
 				"-f", case7BindingYaml1,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case7BindingYaml2,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case7BindingYaml3,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 			utils.Kubectl("delete",
 				"-f", case7BindingYaml4,
-				"-n", testNamespace)
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
 		})
 	})
 })

--- a/test/e2e/case8_metrics_test.go
+++ b/test/e2e/case8_metrics_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Test metrics appear locally", func() {
 		By("Creating " + case8PolicyYaml)
 		utils.Kubectl("apply",
 			"-f", case8PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub)
 		plc := utils.GetWithTimeout(
 			clientHubDynamic, gvrPolicy, case8PolicyName, testNamespace, true, defaultTimeoutSeconds,
 		)
@@ -123,7 +124,8 @@ var _ = Describe("Test metrics appear locally", func() {
 		By("Deleting the policy")
 		utils.Kubectl("delete",
 			"-f", case8PolicyYaml,
-			"-n", testNamespace)
+			"-n", testNamespace,
+			"--kubeconfig="+kubeconfigHub)
 		opt := metav1.ListOptions{}
 		utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		By("Checking metric endpoint for root policy status")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/user"
@@ -30,6 +31,7 @@ var (
 	testNamespace         string
 	clientHub             kubernetes.Interface
 	clientHubDynamic      dynamic.Interface
+	kubeconfigHub         string
 	gvrPolicy             schema.GroupVersionResource
 	gvrPolicyAutomation   schema.GroupVersionResource
 	gvrPolicySet          schema.GroupVersionResource
@@ -51,6 +53,9 @@ func TestE2e(t *testing.T) {
 
 func init() {
 	klog.SetOutput(GinkgoWriter)
+	klog.InitFlags(nil)
+	flag.StringVar(&kubeconfigHub, "kubeconfig_hub", "../../kubeconfig_hub_e2e",
+		"Location of the kubeconfig to use; defaults to current kubeconfig if set to an empty string")
 }
 
 var _ = BeforeSuite(func() {
@@ -85,8 +90,8 @@ var _ = BeforeSuite(func() {
 	gvrNamespace = schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "namespaces",
 	}
-	clientHub = NewKubeClient("", "", "")
-	clientHubDynamic = NewKubeClientDynamic("", "", "")
+	clientHub = NewKubeClient("", kubeconfigHub, "")
+	clientHubDynamic = NewKubeClientDynamic("", kubeconfigHub, "")
 	defaultImageRegistry = "quay.io/open-cluster-management"
 	testNamespace = "policy-propagator-test"
 	defaultTimeoutSeconds = 30

--- a/test/resources/e2e_controller_secret.yaml
+++ b/test/resources/e2e_controller_secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: governance-policy-propagator
+  annotations:
+    kubernetes.io/service-account.name: governance-policy-propagator


### PR DESCRIPTION
Previously, the E2E tests on PRs did not use ServiceAccounts, requiring manual updates for permissions for a code change. This change instead uses ServiceAccounts generated by Kubebuilder.

Ref: https://issues.redhat.com/browse/ACM-3299