### PR TITLE
Drop `ClusterNamespace` internally to prep for Placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ gosec.json
 vendor/
 bin
 testbin/*
+kubeconfig_*

--- a/Makefile
+++ b/Makefile
@@ -260,14 +260,19 @@ e2e-test-coverage-compliance-events-api: e2e-test-compliance-events-api
 e2e-test-policyautomation: E2E_LABEL_FILTER = --label-filter="policyautomation"
 e2e-test-policyautomation: e2e-test
 
+.PHONY: e2e-test-coverage-foreground
+e2e-test-coverage-foreground: LOG_REDIRECT = 
+e2e-test-coverage-foreground: e2e-test-coverage
+
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 TEST_COVERAGE_OUT = coverage_e2e.out
 .PHONY: e2e-run-instrumented
+LOG_REDIRECT ?= &>build/_output/controller.log
 e2e-run-instrumented: e2e-build-instrumented
-	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(TEST_COVERAGE_OUT) &>build/_output/controller.log &
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(TEST_COVERAGE_OUT) $(LOG_REDIRECT) &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -62,11 +62,7 @@ func (r *RootPolicyReconciler) cleanUpOrphanedRplPolicies(
 	log := log.WithValues("policyName", instance.GetName(), "policyNamespace", instance.GetNamespace())
 
 	for _, cluster := range originalCPCS {
-		key := appsv1.PlacementDecision{
-			ClusterName:      cluster.ClusterNamespace,
-			ClusterNamespace: cluster.ClusterNamespace,
-		}
-		if allDecisions[key] {
+		if allDecisions[cluster.ClusterName] {
 			continue
 		}
 
@@ -78,7 +74,7 @@ func (r *RootPolicyReconciler) cleanUpOrphanedRplPolicies(
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.FullNameForPolicy(instance),
-				Namespace: cluster.ClusterNamespace,
+				Namespace: cluster.ClusterName,
 			},
 		}
 
@@ -138,7 +134,7 @@ func (r *RootPolicyReconciler) handleRootPolicy(ctx context.Context, instance *p
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      common.FullNameForPolicy(instance),
-				Namespace: decision.ClusterNamespace,
+				Namespace: decision,
 			},
 		}
 

--- a/controllers/propagator/rootpolicy_controller.go
+++ b/controllers/propagator/rootpolicy_controller.go
@@ -100,6 +100,7 @@ func (r *RootPolicyReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 }
 
 //+kubebuilder:object:root=true
+//+kubebuilder:skip
 
 type GuttedObject struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Also:
- Add `e2e-test-coverage-foreground` target
- Add kubeconfig to `.gitignore`
- Skip `GuttedObject` for generation (This was resulting in an empty `_.yaml` CRD file being generated)