### PR TITLE
Add gosec annotations for sha1 usage

### DIFF
--- a/controllers/complianceeventsapi/server.go
+++ b/controllers/complianceeventsapi/server.go
@@ -3,7 +3,7 @@ package complianceeventsapi
 import (
 	"bytes"
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- for convenience, not cryptography
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -278,7 +278,7 @@ func getPolicyForeignKey(ctx context.Context, goquDB *goqu.Database, pol Policy)
 			return 0, err // This kind of error would have been found during validation
 		}
 
-		sum := sha1.Sum(buf.Bytes())
+		sum := sha1.Sum(buf.Bytes()) // #nosec G401 -- for convenience, not cryptography
 		hash := hex.EncodeToString(sum[:])
 		pol.SpecHash = &hash
 	}

--- a/controllers/complianceeventsapi/types.go
+++ b/controllers/complianceeventsapi/types.go
@@ -2,7 +2,7 @@ package complianceeventsapi
 
 import (
 	"bytes"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- for convenience, not cryptography
 	"database/sql/driver"
 	"encoding/hex"
 	"encoding/json"
@@ -164,7 +164,7 @@ func (p *Policy) Validate() error {
 		} else if buf.String() != *p.Spec {
 			errs = append(errs, fmt.Errorf("%w: policy.spec is not compact JSON", errInvalidInput))
 		} else if p.SpecHash != nil {
-			sum := sha1.Sum(buf.Bytes())
+			sum := sha1.Sum(buf.Bytes()) // #nosec G401 -- for convenience, not cryptography
 
 			if *p.SpecHash != hex.EncodeToString(sum[:]) {
 				errs = append(errs, fmt.Errorf("%w: policy.specHash does not match the compact policy.Spec",


### PR DESCRIPTION
To allow stolostron CI to pass (we should probably bring this gosec scan into open-cluster-management-io...)