### PR TITLE
Remove spec_hash and allow the use of IDs instead

### DIFF
--- a/controllers/complianceeventsapi/migrations/000001_compliance_history_initial_tables.up.sql
+++ b/controllers/complianceeventsapi/migrations/000001_compliance_history_initial_tables.up.sql
@@ -21,17 +21,17 @@ CREATE TABLE IF NOT EXISTS parent_policies(
 
 -- This is required until we only support Postgres 15+ to utilize NULLS NOT DISTINCT.
 -- Partial indexes with 1 nullable unique field provided (e.g. A, B, C)
-CREATE UNIQUE INDEX parent_policies_null1 ON parent_policies (name, namespace, controls, standards) WHERE categories IS NULL;
-CREATE UNIQUE INDEX parent_policies_null2 ON parent_policies (name, namespace, categories, standards) WHERE controls IS NULL;
-CREATE UNIQUE INDEX parent_policies_null3 ON parent_policies (name, namespace, categories, controls) WHERE standards IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null1 ON parent_policies (name, namespace, controls, standards) WHERE categories IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null2 ON parent_policies (name, namespace, categories, standards) WHERE controls IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null3 ON parent_policies (name, namespace, categories, controls) WHERE standards IS NULL;
 
 -- Partial indexes with 2 nullable unique field provided (e.g. AB AC BC)
-CREATE UNIQUE INDEX parent_policies_null4 ON parent_policies (name, namespace, standards) WHERE categories IS NULL AND controls IS NULL;
-CREATE UNIQUE INDEX parent_policies_null5 ON parent_policies (name, namespace, controls) WHERE categories IS NULL AND standards IS NULL;
-CREATE UNIQUE INDEX parent_policies_null6 ON parent_policies (name, namespace, categories) WHERE controls IS NULL AND standards IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null4 ON parent_policies (name, namespace, standards) WHERE categories IS NULL AND controls IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null5 ON parent_policies (name, namespace, controls) WHERE categories IS NULL AND standards IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null6 ON parent_policies (name, namespace, categories) WHERE controls IS NULL AND standards IS NULL;
 
 -- Partial index with no nullable unique fields provided (e.g. ABC)
-CREATE UNIQUE INDEX parent_policies_null7 ON parent_policies (name, namespace) WHERE categories IS NULL AND controls IS NULL AND standards IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS parent_policies_null7 ON parent_policies (name, namespace) WHERE categories IS NULL AND controls IS NULL AND standards IS NULL;
 
 CREATE TABLE IF NOT EXISTS policies(
    id serial PRIMARY KEY,
@@ -39,22 +39,20 @@ CREATE TABLE IF NOT EXISTS policies(
    api_group TEXT NOT NULL,
    name TEXT NOT NULL,
    namespace TEXT,
-   spec TEXT NOT NULL,
-   -- SHA1 hash
-   spec_hash CHAR(40) NOT NULL,
+   spec JSONB NOT NULL,
    severity TEXT,
-   UNIQUE (kind, api_group, name, namespace, spec_hash, severity)
+   UNIQUE (kind, api_group, name, namespace, spec, severity)
 );
 
 -- This is required until we only support Postgres 15+ to utilize NULLS NOT DISTINCT.
 -- Partial indexes with 1 nullable unique field provided (e.g. A, B)
-CREATE UNIQUE INDEX policies_null1 ON policies (kind, api_group, name, spec_hash, severity) WHERE namespace IS NULL;
-CREATE UNIQUE INDEX policies_null2 ON policies (kind, api_group, name, namespace, spec_hash) WHERE severity IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS policies_null1 ON policies (kind, api_group, name, spec, severity) WHERE namespace IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS policies_null2 ON policies (kind, api_group, name, namespace, spec) WHERE severity IS NULL;
 
 -- Partial index with no nullable unique fields provided (e.g. AB)
-CREATE UNIQUE INDEX policies_null3 ON policies (kind, api_group, name, spec_hash) WHERE namespace IS NULL AND severity IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS policies_null3 ON policies (kind, api_group, name, spec) WHERE namespace IS NULL AND severity IS NULL;
 
-CREATE INDEX IF NOT EXISTS idx_policies_spec_hash ON policies (spec_hash);
+CREATE INDEX IF NOT EXISTS idx_policies_spec ON policies (spec);
 
 CREATE TABLE IF NOT EXISTS compliance_events(
    id serial PRIMARY KEY,

--- a/controllers/complianceeventsapi/server.go
+++ b/controllers/complianceeventsapi/server.go
@@ -183,11 +183,11 @@ func postComplianceEvent(db *sql.DB, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getClusterForeignKey(ctx context.Context, db *sql.DB, cluster Cluster) (int, error) {
+func getClusterForeignKey(ctx context.Context, db *sql.DB, cluster Cluster) (int32, error) {
 	// Check cache
 	key, ok := clusterKeyCache.Load(cluster.ClusterID)
 	if ok {
-		return key.(int), nil
+		return key.(int32), nil
 	}
 
 	err := cluster.GetOrCreate(ctx, db)
@@ -200,13 +200,13 @@ func getClusterForeignKey(ctx context.Context, db *sql.DB, cluster Cluster) (int
 	return cluster.KeyID, nil
 }
 
-func getParentPolicyForeignKey(ctx context.Context, db *sql.DB, parent ParentPolicy) (int, error) {
+func getParentPolicyForeignKey(ctx context.Context, db *sql.DB, parent ParentPolicy) (int32, error) {
 	// Check cache
 	parKey := parent.key()
 
 	key, ok := parentPolicyKeyCache.Load(parKey)
 	if ok {
-		return key.(int), nil
+		return key.(int32), nil
 	}
 
 	err := parent.GetOrCreate(ctx, db)
@@ -219,7 +219,7 @@ func getParentPolicyForeignKey(ctx context.Context, db *sql.DB, parent ParentPol
 	return parent.KeyID, nil
 }
 
-func getPolicyForeignKey(ctx context.Context, db *sql.DB, pol Policy) (int, error) {
+func getPolicyForeignKey(ctx context.Context, db *sql.DB, pol Policy) (int32, error) {
 	// Fill in missing fields that can be inferred from other fields
 	if pol.SpecHash == "" {
 		var buf bytes.Buffer
@@ -236,7 +236,7 @@ func getPolicyForeignKey(ctx context.Context, db *sql.DB, pol Policy) (int, erro
 
 	key, ok := policyKeyCache.Load(polKey)
 	if ok {
-		return key.(int), nil
+		return key.(int32), nil
 	}
 
 	if pol.Spec == "" {

--- a/controllers/complianceeventsapi/types.go
+++ b/controllers/complianceeventsapi/types.go
@@ -87,7 +87,7 @@ func (ce *ComplianceEvent) Create(ctx context.Context, db *sql.DB) error {
 }
 
 type Cluster struct {
-	KeyID     int    `db:"id" json:"-"`
+	KeyID     int32  `db:"id" json:"-"`
 	Name      string `db:"name" json:"name"`
 	ClusterID string `db:"cluster_id" json:"cluster_id"` //nolint:tagliatelle
 }
@@ -132,10 +132,10 @@ func (c *Cluster) GetOrCreate(ctx context.Context, db *sql.DB) error {
 }
 
 type EventDetails struct {
-	KeyID          int       `db:"id" json:"-"`
-	ClusterID      int       `db:"cluster_id" json:"-"`
-	PolicyID       int       `db:"policy_id" json:"-"`
-	ParentPolicyID *int      `db:"parent_policy_id" json:"-"`
+	KeyID          int32     `db:"id" json:"-"`
+	ClusterID      int32     `db:"cluster_id" json:"-"`
+	PolicyID       int32     `db:"policy_id" json:"-"`
+	ParentPolicyID *int32    `db:"parent_policy_id" json:"-"`
 	Compliance     string    `db:"compliance" json:"compliance"`
 	Message        string    `db:"message" json:"message"`
 	Timestamp      time.Time `db:"timestamp" json:"timestamp"`
@@ -180,7 +180,7 @@ func (e *EventDetails) InsertQuery() (string, []any) {
 }
 
 type ParentPolicy struct {
-	KeyID      int            `db:"id" json:"-"`
+	KeyID      int32          `db:"id" json:"-"`
 	Name       string         `db:"name" json:"name"`
 	Namespace  string         `db:"namespace" json:"namespace"`
 	Categories pq.StringArray `db:"categories" json:"categories,omitempty"`
@@ -235,7 +235,7 @@ func (p ParentPolicy) key() string {
 }
 
 type Policy struct {
-	KeyID     int     `db:"id" json:"-"`
+	KeyID     int32   `db:"id" json:"-"`
 	Kind      string  `db:"kind" json:"kind"`
 	APIGroup  string  `db:"api_group" json:"apiGroup"`
 	Name      string  `db:"name" json:"name"`
@@ -381,7 +381,7 @@ func getOrCreate(ctx context.Context, db *sql.DB, obj dbRow) error {
 		return row.Err()
 	}
 
-	var primaryKey int
+	var primaryKey int32
 
 	err := row.Scan(&primaryKey)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/controllers/complianceeventsapi/types_test.go
+++ b/controllers/complianceeventsapi/types_test.go
@@ -96,11 +96,7 @@ func TestParentPolicyValidation(t *testing.T) {
 }
 
 func TestPolicyValidation(t *testing.T) {
-	basespec := `{"test":"one","severity":"low"}`
-	basehash := "cb84fe29e44202e3aeb46d39ba46993f60cdc6af"
-	badhash := "foobarbaz"
-	badspec := `{foo: bar: baz`
-	noncompactspec := `{"foo" : "bar"   }`
+	var basespec JSONMap = map[string]interface{}{"test": "one", "severity": "low"}
 
 	tests := map[string]struct {
 		obj    Policy
@@ -111,16 +107,14 @@ func TestPolicyValidation(t *testing.T) {
 				Kind:     "policy",
 				APIGroup: "v1",
 				Spec:     basespec,
-				SpecHash: basehash,
 			},
 			"field not provided: policy.name",
 		},
 		"no API group": {
 			Policy{
-				Kind:     "policy",
-				Name:     "foobar",
-				Spec:     basespec,
-				SpecHash: basehash,
+				Kind: "policy",
+				Name: "foobar",
+				Spec: basespec,
 			},
 			"field not provided: policy.apiGroup",
 		},
@@ -129,7 +123,6 @@ func TestPolicyValidation(t *testing.T) {
 				APIGroup: "v1",
 				Name:     "foobar",
 				Spec:     basespec,
-				SpecHash: basehash,
 			},
 			"field not provided: policy.kind",
 		},
@@ -139,35 +132,7 @@ func TestPolicyValidation(t *testing.T) {
 				APIGroup: "v1",
 				Name:     "foobar",
 			},
-			"field not provided: policy.spec or policy.specHash",
-		},
-		"not valid json": {
-			Policy{
-				Kind:     "policy",
-				APIGroup: "v1",
-				Name:     "foobar",
-				Spec:     badspec,
-			},
-			"policy.spec is not valid JSON",
-		},
-		"not compact json": {
-			Policy{
-				Kind:     "policy",
-				APIGroup: "v1",
-				Name:     "foobar",
-				Spec:     noncompactspec,
-			},
-			"policy.spec is not compact JSON",
-		},
-		"not matching hash": {
-			Policy{
-				Kind:     "policy",
-				APIGroup: "v1",
-				Name:     "foobar",
-				Spec:     basespec,
-				SpecHash: badhash,
-			},
-			"policy.specHash does not match the compact policy.Spec",
+			"field not provided: policy.spec",
 		},
 	}
 


### PR DESCRIPTION
Rather than provide spec_hash, the POST endpoint now accepts a parent
policy ID and/or policy ID. This saves on network bandwidth and resource
utilization when the ID is known.

This also changes spec to be JSONB instead of a JSON string. This allows
a unique constraint without serializing it in a special way with map
keys sorted.

There is also a fix in the select queries with dealing with null values. `= NULL` is always false and what we want is `IS NULL`.

The first commit sets the primary key types to int32 to match the Postgres serial primary key option of values 1 to 2147483647.