### PR TITLE
Don't skip SonarCloud run on `push`

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -191,7 +191,6 @@ jobs:
         working-directory: '.'
     runs-on: ubuntu-latest
     name: Test Coverage Verification
-    if: ${{ github.event_name == 'pull_request' }}
     needs: [unit-tests, kind-tests, policyautomation-tests]
 
     steps:


### PR DESCRIPTION
Followup to:
- #143 