### PR TITLE
Add authorization to the compliance event API endpoints

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -78,6 +78,11 @@ jobs:
     - name: Checkout Governance Policy Propagator
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:
         KIND_VERSION: ${{ matrix.kind }}
@@ -148,6 +153,12 @@ jobs:
     steps:
     - name: Checkout Governance Policy Propagator
       uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      id: go
+      with:
+        go-version-file: go.mod
 
     - name: Create K8s KinD Cluster - ${{ matrix.kind }}
       env:

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,9 @@ install-resources:
 	kubectl create ns managed1
 	kubectl create ns managed2
 	kubectl create ns managed3
+	kubectl create ns managed4
+	kubectl create ns managed5
+	kubectl create ns managed6
 	@echo deploying roles and service account
 	kubectl apply -k deploy/rbac -n $(KIND_NAMESPACE)
 	kubectl apply -f deploy/manager/service-account.yaml -n $(KIND_NAMESPACE)
@@ -245,6 +248,9 @@ install-resources:
 	kubectl apply -f test/resources/managed1-cluster.yaml
 	kubectl apply -f test/resources/managed2-cluster.yaml
 	kubectl apply -f test/resources/managed3-cluster.yaml
+	kubectl apply -f test/resources/managed4-cluster.yaml
+	kubectl apply -f test/resources/managed5-cluster.yaml
+	kubectl apply -f test/resources/managed6-cluster.yaml
 	@echo setting a Hub cluster DNS name
 	kubectl apply -f test/resources/case5_policy_automation/cluster-dns.yaml
 

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
+	github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -214,6 +214,8 @@ github.com/stolostron/go-template-utils/v4 v4.0.1-0.20231212190701-4dc096ec1b40 
 github.com/stolostron/go-template-utils/v4 v4.0.1-0.20231212190701-4dc096ec1b40/go.mod h1:HtsbCTMS4oFBQpy8le4/Td1YTsHfsh1aP8uRMcquaHI=
 github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8 h1:fA4m/qD8S/l4jSyf2W/eG1iCSnokRXfkoKde4Ohy1f8=
 github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8/go.mod h1:8vRsL1GGBw0jjCwP8CH8d30NVNYKhUy0rdBSQZ2znx8=
+github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398 h1:lDYoE83J3+fekj/RstoHitheBEGKYwqjRlNhoTGq698=
+github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398/go.mod h1:zYGYkVgY+sL501na1x5RDCKMrHD+JAwb6oRFU8e9XlU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/test/e2e/case19_rep_policy_placement_test.go
+++ b/test/e2e/case19_rep_policy_placement_test.go
@@ -230,12 +230,15 @@ var _ = Describe("Test replicated_policy controller and propagation", Ordered, S
 			clientHubDynamic, gvrPolicy, testNamespace+"."+case19PolicyName, "managed2", true, defaultTimeoutSeconds,
 		)
 		Expect(plc2).ToNot(BeNil())
-		afterString = utils.GetMetrics("controller_runtime_reconcile_total",
-			`controller=\"replicated-policy\"`,
-			`,result=\"success\"`,
-		)[0]
-		afterTotal, err = strconv.Atoi(afterString)
-		Expect(err).ShouldNot(HaveOccurred())
-		Expect(afterTotal - beforeTotal).Should(Equal(2))
+
+		Eventually(func(g Gomega) {
+			afterString = utils.GetMetrics("controller_runtime_reconcile_total",
+				`controller=\"replicated-policy\"`,
+				`,result=\"success\"`,
+			)[0]
+			afterTotal, err = strconv.Atoi(afterString)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(afterTotal - beforeTotal).Should(Equal(2))
+		}).Should(Succeed())
 	})
 })

--- a/test/e2e/case20_compliance_api_controller_test.go
+++ b/test/e2e/case20_compliance_api_controller_test.go
@@ -204,6 +204,10 @@ func bringDownDBConnection(ctx context.Context) {
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 
+		// Set auth token
+		token := getToken(ctx, "open-cluster-management", "governance-policy-propagator")
+		req.Header.Set("Authorization", "Bearer "+token)
+
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			return

--- a/test/resources/case18_compliance_api_test/subset_service_account.yaml
+++ b/test/resources/case18_compliance_api_test/subset_service_account.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: subset-sa
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: subset-sa
+  annotations:
+    kubernetes.io/service-account.name: subset-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: subset-cluster-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - watch
+- apiGroups:
+  - 'cluster.open-cluster-management.io'
+  resources:
+  - managedclusters
+  resourceNames:
+  - managed1
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: subset-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: subset-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: subset-sa
+  namespace: default

--- a/test/resources/case18_compliance_api_test/wrong_service_account.yaml
+++ b/test/resources/case18_compliance_api_test/wrong_service_account.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: wrong-sa
+  namespace: default
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: wrong-sa
+  annotations:
+    kubernetes.io/service-account.name: wrong-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: wrong-cluster-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: wrong-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wrong-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: wrong-sa
+  namespace: default

--- a/test/resources/managed4-cluster.yaml
+++ b/test/resources/managed4-cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: managed4
+    vendor: auto-detect
+  name: managed4
+  namespace: managed4
+spec: {}

--- a/test/resources/managed5-cluster.yaml
+++ b/test/resources/managed5-cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: managed5
+    vendor: auto-detect
+  name: managed5
+  namespace: managed5
+spec: {}

--- a/test/resources/managed6-cluster.yaml
+++ b/test/resources/managed6-cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: managed6
+    vendor: auto-detect
+  name: managed6
+  namespace: managed6
+spec: {}


### PR DESCRIPTION
I need to ensure that the compliance history can only be written by authorized service accounts and viewed by users with appropriate ACM access. 

**Definition of Done for Engineering Story Owner (Checklist)**
- The read API endpoint is restricted based on a user's "get" access to corresponding ManagedCluster objects. This result will filter the requests returned in the SQL queries.

Ref: https://issues.redhat.com/browse/ACM-6866
Signed-off-by: Yi Rae Kim <yikim@redhat.com>