### PR TITLE
Add back propagation/update events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build-images:
 
 .PHONY: run
 run:
-	WATCH_NAMESPACE="" go run main.go --leader-elect=false --log-level=2
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" go run main.go --leader-elect=false --enable-webhooks=false --log-level=2
 
 ############################################################
 # Generate manifests
@@ -264,19 +264,14 @@ e2e-test-coverage-compliance-events-api: e2e-test-compliance-events-api
 e2e-test-policyautomation: E2E_LABEL_FILTER = --label-filter="policyautomation"
 e2e-test-policyautomation: e2e-test
 
-.PHONY: e2e-test-coverage-foreground
-e2e-test-coverage-foreground: LOG_REDIRECT = 
-e2e-test-coverage-foreground: e2e-test-coverage
-
 .PHONY: e2e-build-instrumented
 e2e-build-instrumented:
 	go test -covermode=atomic -coverpkg=$(shell cat go.mod | head -1 | cut -d ' ' -f 2)/... -c -tags e2e ./ -o build/_output/bin/$(IMG)-instrumented
 
 TEST_COVERAGE_OUT = coverage_e2e.out
 .PHONY: e2e-run-instrumented
-LOG_REDIRECT ?= &>build/_output/controller.log
 e2e-run-instrumented: e2e-build-instrumented
-	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(TEST_COVERAGE_OUT) $(LOG_REDIRECT) &
+	WATCH_NAMESPACE="$(WATCH_NAMESPACE)" ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(TEST_COVERAGE_OUT) 2>&1 | tee ./build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/controllers/propagator/replicatedpolicy_controller.go
+++ b/controllers/propagator/replicatedpolicy_controller.go
@@ -290,6 +290,10 @@ func (r *ReplicatedPolicyReconciler) Reconcile(ctx context.Context, request ctrl
 			return reconcile.Result{}, err
 		}
 
+		r.Recorder.Event(rootPolicy, "Normal", "PolicyPropagation",
+			fmt.Sprintf("Policy %s/%s was propagated to cluster %s/%s", rootPolicy.GetNamespace(),
+				rootPolicy.GetName(), decision.Cluster.ClusterName, decision.Cluster.ClusterNamespace))
+
 		version.resourceVersion = desiredReplicatedPolicy.GetResourceVersion()
 
 		log.Info("Created replicated policy")
@@ -312,6 +316,10 @@ func (r *ReplicatedPolicyReconciler) Reconcile(ctx context.Context, request ctrl
 
 			return reconcile.Result{}, err
 		}
+
+		r.Recorder.Event(rootPolicy, "Normal", "PolicyPropagation",
+			fmt.Sprintf("Policy %s/%s was updated for cluster %s/%s", rootPolicy.GetNamespace(),
+				rootPolicy.GetName(), decision.Cluster.ClusterName, decision.Cluster.ClusterNamespace))
 
 		log.Info("Replicated policy updated")
 	} else {


### PR DESCRIPTION
- Add back propagation/update events
- Also updates `make run` so that it works (since the webhook had to be disabled).

ref: https://issues.redhat.com/browse/ACM-9461