### PR TITLE
Add certificate and token auth and authz on the POST API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ bin
 testbin/*
 
 kubeconfig*
+dev-tls.crt
+dev-tls.key

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,11 @@ postgres: cert-manager
 		--from-literal="host=$(POSTGRES_HOST)" \
 		--from-literal="dbname=ocm-compliance-history" \
 		--from-literal="ca=$$(kubectl -n $(KIND_NAMESPACE) get secret postgres-cert -o json | jq -r '.data["ca.crt"]' | base64 -d)"
+	
+	@echo "Copying the compliance API certificates locally"
+	kubectl -n $(KIND_NAMESPACE) get secret compliance-api-cert -o json | jq -r '.data["tls.crt"]' | base64 -d > dev-tls.crt
+	kubectl -n $(KIND_NAMESPACE) get secret compliance-api-cert -o json | jq -r '.data["ca.crt"]' | base64 -d >> dev-ca.crt
+	kubectl -n $(KIND_NAMESPACE) get secret compliance-api-cert -o json | jq -r '.data["tls.key"]' | base64 -d > dev-tls.key
 
 webhook: cert-manager
 	-kubectl create ns $(KIND_NAMESPACE)

--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -158,9 +158,11 @@ kind-ensure-sa:
 kind-controller-kubeconfig: install-resources
 	kubectl -n $(CONTROLLER_NAMESPACE) apply -f test/resources/e2e_controller_secret.yaml --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME)_e2e
 	-rm kubeconfig_$(CLUSTER_NAME)
+	@kubectl config view --minify -o jsonpath='{.clusters[].cluster.certificate-authority-data}' --kubeconfig=kubeconfig_$(CLUSTER_NAME)_e2e --raw | base64 -d > temp-ca.crt
 	@kubectl config set-cluster $(KIND_CLUSTER_NAME) --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME) \
 		--server=$(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}' --kubeconfig=kubeconfig_$(CLUSTER_NAME)_e2e) \
-		--insecure-skip-tls-verify=true
+		--certificate-authority=temp-ca.crt --embed-certs=true
+	@rm -f temp-ca.crt
 	@kubectl config set-credentials $(KIND_CLUSTER_NAME) --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME) \
 		--token=$$(kubectl get secret -n $(CONTROLLER_NAMESPACE) $(CONTROLLER_NAME) -o jsonpath='{.data.token}' --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME)_e2e | $(BASE64) --decode)
 	@kubectl config set-context $(KIND_CLUSTER_NAME) --kubeconfig=$(PWD)/kubeconfig_$(CLUSTER_NAME) \

--- a/build/kind/postgres.yaml
+++ b/build/kind/postgres.yaml
@@ -133,3 +133,26 @@ spec:
       targetPort: 8384
       nodePort: 30838
   type: NodePort
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: compliance-api-selfsigned-issuer
+  namespace: open-cluster-management
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: compliance-api-cert
+  namespace: open-cluster-management
+spec:
+  dnsNames:
+    - compliance-api-external.open-cluster-management.svc
+    - compliance-api-external.open-cluster-management.svc.cluster.local
+    - localhost
+  issuerRef:
+    kind: Issuer
+    name: compliance-api-selfsigned-issuer
+  secretName: compliance-api-cert

--- a/controllers/complianceeventsapi/auth.go
+++ b/controllers/complianceeventsapi/auth.go
@@ -1,0 +1,190 @@
+// Copyright Contributors to the Open Cluster Management project
+package complianceeventsapi
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	authzv1 "k8s.io/api/authorization/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiserverx509 "k8s.io/apiserver/pkg/authentication/request/x509"
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// parseToken will return the token string in the Authorization header.
+func parseToken(req *http.Request) string {
+	return strings.TrimSpace(strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer"))
+}
+
+// getClientFromToken will generate a Kubernetes client using the input config and token. No authentication data from
+// the input config is used in the generated client.
+func getClientFromToken(cfg *rest.Config, token string) (*kubernetes.Clientset, error) {
+	userConfig := &rest.Config{
+		Host:    cfg.Host,
+		APIPath: cfg.APIPath,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAFile:     cfg.TLSClientConfig.CAFile,
+			CAData:     cfg.TLSClientConfig.CAData,
+			ServerName: cfg.TLSClientConfig.ServerName,
+			Insecure:   cfg.TLSClientConfig.Insecure,
+		},
+		BearerToken: token,
+	}
+
+	return kubernetes.NewForConfig(userConfig)
+}
+
+// canRecordComplianceEvent will perform certificate or token authentication and perform a subject access review to
+// ensure the input user has patch access to patch the policy status in the managed cluster namespace. An error is
+// returned if the authorization could not be determined. Note that authenticatedClient and authenticator can be nil
+// if certificate authentication isn't used. If both certificate and token authentication is present, certificate takes
+// precedence.
+func canRecordComplianceEvent(
+	cfg *rest.Config,
+	authenticatedClient *kubernetes.Clientset,
+	authenticator *apiserverx509.Authenticator,
+	clusterName string,
+	req *http.Request,
+) (bool, error) {
+	postRules := authzv1.ResourceAttributes{
+		Group:       "policy.open-cluster-management.io",
+		Version:     "v1",
+		Resource:    "policies",
+		Verb:        "patch",
+		Namespace:   clusterName,
+		Subresource: "status",
+	}
+
+	// req.TLS.PeerCertificates will be empty if certificate authentication is not enabled (e.g. endpoint is not HTTPS)
+	if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
+		resp, ok, err := authenticator.AuthenticateRequest(req)
+		if err != nil {
+			if errors.As(err, &x509.UnknownAuthorityError{}) || errors.As(err, &x509.CertificateInvalidError{}) {
+				return false, ErrNotAuthorized
+			}
+
+			return false, err
+		}
+
+		if !ok {
+			return false, ErrNotAuthorized
+		}
+
+		review, err := authenticatedClient.AuthorizationV1().SubjectAccessReviews().Create(
+			req.Context(),
+			&authzv1.SubjectAccessReview{
+				Spec: authzv1.SubjectAccessReviewSpec{
+					ResourceAttributes: &postRules,
+					User:               resp.User.GetName(),
+					Groups:             resp.User.GetGroups(),
+					UID:                resp.User.GetUID(),
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			return false, err
+		}
+
+		if !review.Status.Allowed {
+			log.V(0).Info(
+				"The user is not authorized to record a compliance event",
+				"cluster", clusterName,
+				"user", resp.User.GetName(),
+			)
+		}
+
+		return review.Status.Allowed, nil
+	}
+
+	token := parseToken(req)
+	if token == "" {
+		return false, ErrNotAuthorized
+	}
+
+	userClient, err := getClientFromToken(cfg, token)
+	if err != nil {
+		return false, err
+	}
+
+	result, err := userClient.AuthorizationV1().SelfSubjectAccessReviews().Create(
+		req.Context(),
+		&authzv1.SelfSubjectAccessReview{
+			Spec: authzv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &postRules,
+			},
+		},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		if k8serrors.IsUnauthorized(err) {
+			return false, ErrNotAuthorized
+		}
+
+		return false, err
+	}
+
+	if !result.Status.Allowed {
+		log.V(0).Info(
+			"The user is not authorized to record a compliance event",
+			"cluster", clusterName,
+			"user", getTokenUsername(token),
+		)
+	}
+
+	return result.Status.Allowed, nil
+}
+
+// getTokenUsername will parse the token and return the username. If the token is invalid, an empty string is returned.
+func getTokenUsername(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		log.V(2).Info("The token does not have the expected three parts")
+
+		return ""
+	}
+
+	userInfoBytes, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		log.V(2).Info("The token does not have valid base64")
+
+		return ""
+	}
+
+	userInfo := map[string]interface{}{}
+
+	err = json.Unmarshal(userInfoBytes, &userInfo)
+	if err != nil {
+		log.V(2).Info("The token does not have valid JSON")
+
+		return ""
+	}
+
+	username, ok := userInfo["sub"].(string)
+	if !ok {
+		return ""
+	}
+
+	return username
+}
+
+// getCertAuthenticator returns an Authenticator that can validate that an input certificate is signed by the API
+// server represented in the input cfg and that the certificate can be used for client authentication (e.g. key usage).
+func getCertAuthenticator(cfg *rest.Config) (*apiserverx509.Authenticator, error) {
+	p, err := dynamiccertificates.NewStaticCAContent("client-ca", cfg.CAData)
+	if err != nil {
+		return nil, err
+	}
+
+	// This is the same approach taken by kube-rbac-proxy.
+	authenticator := apiserverx509.NewDynamic(p.VerifyOptions, apiserverx509.CommonNameUserConversion)
+
+	return authenticator, nil
+}

--- a/controllers/complianceeventsapi/auth_test.go
+++ b/controllers/complianceeventsapi/auth_test.go
@@ -1,0 +1,23 @@
+package complianceeventsapi
+
+import (
+	"testing"
+)
+
+func TestGetTokenUsername(t *testing.T) {
+	t.Parallel()
+
+	token := "part1.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc" +
+		"3BhY2UiOiJvcGVuLWNsdXN0ZXItbWFuYWdlbWVudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJnb3Zl" +
+		"cm5hbmNlLXBvbGljeS1wcm9wYWdhdG9yIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Imdv" +
+		"dmVybmFuY2UtcG9saWN5LXByb3BhZ2F0b3IiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJ" +
+		"lMjQzZDBlNi03YjJkLTRjZjQtYmExMC1mMTE5NWQwMGUxZTYiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3Blbi1jbHVzdGVyLW" +
+		"1hbmFnZW1lbnQ6Z292ZXJuYW5jZS1wb2xpY3ktcHJvcGFnYXRvciJ9.part3"
+
+	username := getTokenUsername(token)
+	expected := "system:serviceaccount:open-cluster-management:governance-policy-propagator"
+
+	if username != expected {
+		t.Fatalf("Expected %s but got %s", expected, username)
+	}
+}

--- a/controllers/complianceeventsapi/complianceeventsapi_controller.go
+++ b/controllers/complianceeventsapi/complianceeventsapi_controller.go
@@ -121,6 +121,7 @@ type ComplianceDBSecretReconciler struct {
 // WARNING: In production, this should be namespaced to the namespace the controller is running in.
 //+kubebuilder:rbac:groups=core,resources=secrets,resourceNames=governance-policy-database,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 // Reconcile watches the governance-policy-database secret in the controller namespace. On updates it'll trigger
 // a database migration and update the shared database connection.

--- a/deploy/manager/manager.yaml
+++ b/deploy/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=:8383"
             - "--leader-elect"
-            - "--event-history-api-host=0.0.0.0"
+            - "--compliance-history-api-host=0.0.0.0"
           ports:
             - containerPort: 8383
               protocol: TCP

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -52,6 +52,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters
@@ -275,7 +281,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8383
         - --leader-elect
-        - --event-history-api-host=0.0.0.0
+        - --compliance-history-api-host=0.0.0.0
         command:
         - governance-policy-propagator
         env:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -23,6 +23,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - cluster.open-cluster-management.io
   resources:
   - managedclusters

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang-migrate/migrate/v4 v4.16.2
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.3.1
 	github.com/lib/pq v1.10.9
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.28.1
@@ -17,6 +18,7 @@ require (
 	github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8
 	k8s.io/api v0.27.7
 	k8s.io/apimachinery v0.27.7
+	k8s.io/apiserver v0.27.7
 	k8s.io/client-go v0.27.7
 	k8s.io/klog/v2 v2.100.1
 	open-cluster-management.io/api v0.12.0
@@ -29,6 +31,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
@@ -46,7 +49,6 @@ require (
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20231023181126-ff6d637d2a7b // indirect
-	github.com/google/uuid v1.3.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -362,6 +364,8 @@ k8s.io/apiextensions-apiserver v0.27.7 h1:YqIOwZAUokzxJIjunmUd4zS1v3JhK34EPXn+pP
 k8s.io/apiextensions-apiserver v0.27.7/go.mod h1:x0p+b5a955lfPz9gaDeBy43obM12s+N9dNHK6+dUL+g=
 k8s.io/apimachinery v0.27.7 h1:Gxgtb7Y/Rsu8ymgmUEaiErkxa6RY4oTd8kNUI6SUR58=
 k8s.io/apimachinery v0.27.7/go.mod h1:jBGQgTjkw99ef6q5hv1YurDd3BqKDk9YRxmX0Ozo0i8=
+k8s.io/apiserver v0.27.7 h1:E8sDHwfUug82YC1++qvE73QxihaXDqT4tr8XYBOEtc4=
+k8s.io/apiserver v0.27.7/go.mod h1:OrLG9RwCOerutAlo8QJW5EHzUG9Dad7k6rgcDUNSO/w=
 k8s.io/client-go v0.27.7 h1:+Xgh9OOKv6A3qdD4Dnl/0VOI5EvAv+0s/OseDxVVTwQ=
 k8s.io/client-go v0.27.7/go.mod h1:dZ2kqcalYp5YZ2EV12XIMc77G6PxHWOJp/kclZr4+5Q=
 k8s.io/component-base v0.27.7 h1:kngM58HR9W9Nqpv7e4rpdRyWnKl/ABpUhLAZ+HoliMs=

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,9 @@ func TestRunMain(t *testing.T) {
 	os.Args = append(os.Args,
 		"--leader-elect=false",
 		"--enable-webhooks=false",
-		"--event-history-api-port=8385",
+		"--compliance-history-api-port=8385",
+		"--compliance-history-api-cert=dev-tls.crt",
+		"--compliance-history-api-key=dev-tls.key",
 	)
 
 	main()

--- a/test/e2e/case20_compliance_api_controller_test.go
+++ b/test/e2e/case20_compliance_api_controller_test.go
@@ -3,19 +3,32 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
+	cryptorand "crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"math/rand"
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	certutil "k8s.io/client-go/util/cert"
 
 	"open-cluster-management.io/governance-policy-propagator/controllers/complianceeventsapi"
 	"open-cluster-management.io/governance-policy-propagator/controllers/propagator"
@@ -187,7 +200,7 @@ func bringDownDBConnection(ctx context.Context) {
 	By("Waiting for the database connection to be down")
 	EventuallyWithOffset(1, func(g Gomega) {
 		req, err := http.NewRequestWithContext(
-			ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/api/v1/compliance-events/1", complianceAPIPort), nil,
+			ctx, http.MethodGet, fmt.Sprintf("https://localhost:%d/api/v1/compliance-events/1", complianceAPIPort), nil,
 		)
 		g.Expect(err).ToNot(HaveOccurred())
 
@@ -211,3 +224,348 @@ func bringDownDBConnection(ctx context.Context) {
 		g.Expect(respJSON["message"]).To(Equal("The database is unavailable"))
 	}, defaultTimeoutSeconds, 1).Should(Succeed())
 }
+
+var _ = Describe("Test compliance events API authentication and authorization", Serial, Ordered, func() {
+	eventsEndpoint := fmt.Sprintf("https://localhost:%d/api/v1/compliance-events", complianceAPIPort)
+	const saName string = "compliance-api-user"
+	var token string
+	var clientCert tls.Certificate
+
+	getSamplePostRequest := func(clusterName string) *bytes.Buffer {
+		payload := []byte(fmt.Sprintf(`{
+			"cluster": {
+				"name": "%s",
+				"cluster_id": "%s"
+			},
+			"policy": {
+				"apiGroup": "policy.open-cluster-management.io",
+				"kind": "ConfigurationPolicy",
+				"name": "etcd-encryption",
+				"spec": {"uid": "%s"}
+			},
+			"event": {
+				"compliance": "NonCompliant",
+				"message": "configmaps [etcd] not found in namespace default",
+				"timestamp": "2023-02-02T02:02:02.222Z"
+			}
+		}`, clusterName, uuid.New().String(), uuid.New().String()))
+
+		return bytes.NewBuffer(payload)
+	}
+
+	BeforeAll(func(ctx context.Context) {
+		By("Creating the service account " + saName + " in the namespace" + testNamespace)
+		_, err := clientHub.CoreV1().ServiceAccounts(testNamespace).Create(
+			ctx,
+			&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: testNamespace,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = clientHub.CoreV1().Secrets(testNamespace).Create(
+			ctx,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						corev1.ServiceAccountNameKey: saName,
+					},
+				},
+				Type: corev1.SecretTypeServiceAccountToken,
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Granting the service account " + saName + " permission to the cluster namespace " + testNamespace)
+		_, err = clientHub.RbacV1().Roles(testNamespace).Create(
+			ctx,
+			&rbacv1.Role{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: testNamespace,
+				},
+				Rules: []rbacv1.PolicyRule{
+					{
+						APIGroups: []string{"policy.open-cluster-management.io"},
+						Resources: []string{"policies/status"},
+						Verbs:     []string{"patch"},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = clientHub.RbacV1().RoleBindings(testNamespace).Create(
+			ctx,
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      saName,
+					Namespace: testNamespace,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      "ServiceAccount",
+						Name:      saName,
+						Namespace: testNamespace,
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "Role",
+					Name:     saName,
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			secret, err := clientHub.CoreV1().Secrets(testNamespace).Get(ctx, saName, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+
+			g.Expect(secret.Data["token"]).ToNot(BeNil())
+
+			token = string(secret.Data["token"])
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		privateKey, err := rsa.GenerateKey(cryptorand.Reader, 2048)
+		Expect(err).ToNot(HaveOccurred())
+
+		csr, err := certutil.MakeCSR(
+			privateKey,
+			&pkix.Name{CommonName: fmt.Sprintf("system:serviceaccount:%s:%s", testNamespace, saName)},
+			nil,
+			nil,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		csrObj, err := clientHub.CertificatesV1().CertificateSigningRequests().Create(
+			ctx,
+			&certv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: saName,
+				},
+				Spec: certv1.CertificateSigningRequestSpec{
+					Request:    csr,
+					SignerName: certv1.KubeAPIServerClientSignerName,
+					Usages: []certv1.KeyUsage{
+						certv1.UsageDigitalSignature,
+						certv1.UsageKeyEncipherment,
+						certv1.UsageClientAuth,
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		csrObj.Status.Conditions = append(csrObj.Status.Conditions, certv1.CertificateSigningRequestCondition{
+			Type:           certv1.CertificateApproved,
+			Reason:         "test",
+			Message:        "This CSR was approved by the test",
+			LastUpdateTime: metav1.Now(),
+			Status:         corev1.ConditionTrue,
+		})
+
+		_, err = clientHub.CertificatesV1().CertificateSigningRequests().UpdateApproval(
+			ctx, saName, csrObj, metav1.UpdateOptions{},
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			csrObj, err = clientHub.CertificatesV1().CertificateSigningRequests().Get(ctx, saName, metav1.GetOptions{})
+			g.Expect(csrObj.Status.Certificate).ToNot(BeNil())
+		}, defaultTimeoutSeconds, 1).Should(Succeed())
+
+		keyPem := pem.EncodeToMemory(&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+		})
+
+		clientCert, err = tls.X509KeyPair(csrObj.Status.Certificate, keyPem)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterAll(func(ctx context.Context) {
+		By("Deleting the service account")
+		err := clientHub.CoreV1().ServiceAccounts(testNamespace).Delete(ctx, saName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		err = clientHub.CoreV1().Secrets(testNamespace).Delete(ctx, saName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		err = clientHub.RbacV1().Roles(testNamespace).Delete(ctx, saName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		err = clientHub.RbacV1().RoleBindings(testNamespace).Delete(ctx, saName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		err = clientHub.CertificatesV1().CertificateSigningRequests().Delete(ctx, saName, metav1.DeleteOptions{})
+		if !k8serrors.IsNotFound(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		By("Deleting all database records")
+		connectionURL := "postgresql://grc:grc@localhost:5432/ocm-compliance-history?sslmode=disable"
+		db, err := sql.Open("postgres", connectionURL)
+		DeferCleanup(func() {
+			Expect(db.Close()).To(Succeed())
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = db.ExecContext(ctx, "DELETE FROM compliance_events")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = db.ExecContext(ctx, "DELETE FROM clusters")
+		Expect(err).ToNot(HaveOccurred())
+		_, err = db.ExecContext(ctx, "DELETE FROM policies")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Rejects recording the compliance event without authentication", func(ctx context.Context) {
+		payload := getSamplePostRequest("cluster")
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("Rejects recording the compliance event for the wrong namespace (token auth)", func(ctx context.Context) {
+		payload := getSamplePostRequest("cluster")
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+	})
+
+	It("Rejects recording the compliance event for the wrong namespace (cert auth)", func(ctx context.Context) {
+		payload := getSamplePostRequest("cluster")
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+
+		httpClient := http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, Certificates: []tls.Certificate{clientCert}},
+			},
+		}
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+	})
+
+	It("Rejects recording the compliance event with cert signed by unknown CA (cert auth)", func(ctx context.Context) {
+		payload := getSamplePostRequest(testNamespace)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+
+		cert, key, err := certutil.GenerateSelfSignedCertKey("test.local", nil, nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		badClientCert, err := tls.X509KeyPair(cert, key)
+		Expect(err).ToNot(HaveOccurred())
+
+		httpClient := http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, Certificates: []tls.Certificate{badClientCert}},
+			},
+		}
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("Allows recording the compliance event (token auth)", func(ctx context.Context) {
+		payload := getSamplePostRequest(testNamespace)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+	})
+
+	It("Allows recording the compliance event (cert auth)", func(ctx context.Context) {
+		payload := getSamplePostRequest(testNamespace)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, eventsEndpoint, payload)
+		Expect(err).ToNot(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+
+		httpClient := http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true, Certificates: []tls.Certificate{clientCert}},
+			},
+		}
+
+		resp, err := httpClient.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		Expect(resp.StatusCode).To(Equal(http.StatusCreated))
+	})
+})


### PR DESCRIPTION
If a certificate is provided, the HTTP server will run over HTTPS which enables certificate authentication.

The authorization requires a user to have patch access to the policy status on the managed cluster namespace of the managed cluster that the compliance event is for.

Relates:
https://issues.redhat.com/browse/ACM-6866