### PR TITLE
Fix status update with faulty PlacementBinding

### DIFF
--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -211,8 +211,11 @@ func HasValidPlacementRef(pb *policiesv1.PlacementBinding) bool {
 func GetDecisions(
 	ctx context.Context, c client.Client, pb *policiesv1.PlacementBinding,
 ) ([]string, error) {
+	// If the PlacementRef is invalid, log and return. (This is not recoverable.)
 	if !HasValidPlacementRef(pb) {
-		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
+		log.Info(fmt.Sprintf("PlacementBinding %s/%s placementRef is not valid. Ignoring.", pb.Namespace, pb.Name))
+
+		return nil, nil
 	}
 
 	clusterDecisions := make([]string, 0)

--- a/controllers/common/common.go
+++ b/controllers/common/common.go
@@ -212,7 +212,7 @@ func GetDecisions(
 	ctx context.Context, c client.Client, pb *policiesv1.PlacementBinding,
 ) ([]string, error) {
 	if !HasValidPlacementRef(pb) {
-		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+		return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 	}
 
 	clusterDecisions := make([]string, 0)
@@ -266,7 +266,7 @@ func GetDecisions(
 		return clusterDecisions, nil
 	}
 
-	return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+	return nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 }
 
 func ParseRootPolicyLabel(rootPlc string) (name, namespace string, err error) {

--- a/controllers/common/common_status_update.go
+++ b/controllers/common/common_status_update.go
@@ -70,7 +70,7 @@ func GetPolicyPlacementDecisions(ctx context.Context, c client.Client,
 	instance *policiesv1.Policy, pb *policiesv1.PlacementBinding,
 ) (clusterDecisions []string, placements []*policiesv1.Placement, err error) {
 	if !HasValidPlacementRef(pb) {
-		return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Name, pb.Namespace)
+		return nil, nil, fmt.Errorf("placement binding %s/%s reference is not valid", pb.Namespace, pb.Name)
 	}
 
 	policySubjectFound := false

--- a/test/e2e/case2_aggregation_test.go
+++ b/test/e2e/case2_aggregation_test.go
@@ -19,9 +19,35 @@ var _ = Describe("Test policy status aggregation", func() {
 	const (
 		case2PolicyName string = "case2-test-policy"
 		case2PolicyYaml string = "../resources/case2_aggregation/case2-test-policy.yaml"
+		faultyPBName    string = "case2-faulty-placementbinding"
+		faultyPBYaml    string = "../resources/case2_aggregation/faulty-placementbinding.yaml"
 	)
 
-	Describe("Root status from different placements", func() {
+	Describe("Root status from different placements", Ordered, func() {
+		AfterAll(func() {
+			utils.Kubectl("delete",
+				"-f", faultyPBYaml,
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
+			utils.Kubectl("delete",
+				"-f", case2PolicyYaml,
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
+			opt := metav1.ListOptions{}
+			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
+		})
+
+		It("should create the faulty PlacementBinding in user ns", func() {
+			By("Creating " + faultyPBName)
+			utils.Kubectl("apply",
+				"-f", faultyPBYaml,
+				"-n", testNamespace,
+				"--kubeconfig="+kubeconfigHub)
+			pb := utils.GetWithTimeout(
+				clientHubDynamic, gvrPlacementBinding, faultyPBName, testNamespace, true, defaultTimeoutSeconds,
+			)
+			Expect(pb).NotTo(BeNil())
+		})
 		It("should be created in user ns", func() {
 			By("Creating " + case2PolicyYaml)
 			utils.Kubectl("apply",
@@ -220,14 +246,6 @@ var _ = Describe("Test policy status aggregation", func() {
 
 				return rootPlc.Object["status"]
 			}, defaultTimeoutSeconds, 1).Should(utils.SemanticEqual(emptyStatus))
-		})
-		It("should clean up", func() {
-			utils.Kubectl("delete",
-				"-f", case2PolicyYaml,
-				"-n", testNamespace,
-				"--kubeconfig="+kubeconfigHub)
-			opt := metav1.ListOptions{}
-			utils.ListWithTimeout(clientHubDynamic, gvrPolicy, opt, 0, false, 10)
 		})
 	})
 	Describe("Root compliance from managed statuses", Ordered, func() {

--- a/test/resources/case2_aggregation/faulty-placementbinding.yaml
+++ b/test/resources/case2_aggregation/faulty-placementbinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: case2-faulty-placementbinding
+placementRef:
+  apiGroup: cluster.open-cluster-management.io
+  kind: PlacementRule
+  name: case2-test-policy-plr
+subjects:
+- apiGroup: policy.open-cluster-management.io
+  kind: Policy
+  name: rando-policy


### PR DESCRIPTION
With a `PlacementBinding` containing an invalid `placementRef`, the propagator was returning an error and endlessly re-reconciling. This occurs even if the `PlacementBinding` was not bound to the Policy.

Also swaps the namespace and name in the message because it was non-standard.

ref: https://issues.redhat.com/browse/ACM-9930