### PR TITLE
Use `HaveOccurred()` for E2E error checking

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -298,11 +298,14 @@ func Kubectl(args ...string) {
 
 // KubectlWithOutput execute kubectl cli and return output and error
 func KubectlWithOutput(args ...string) (string, error) {
-	output, err := exec.Command("kubectl", args...).CombinedOutput()
-	//nolint:forbidigo
-	fmt.Println(string(output))
+	kubectlCmd := exec.Command("kubectl", args...)
 
-	return string(output), err
+	output, err := kubectlCmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("error running kubectl command: %s: %s", output, err.Error())
+	}
+
+	return string(output), nil
 }
 
 // GetMetrics execs into the propagator pod and curls the metrics endpoint, filters

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -160,7 +160,7 @@ func GetClusterLevelWithTimeout(
 		}
 
 		return nil
-	}, timeout, 1).Should(BeNil())
+	}, timeout, 1).ShouldNot(HaveOccurred())
 
 	if wantFound {
 		return obj
@@ -202,7 +202,7 @@ func GetWithTimeout(
 		}
 
 		return nil
-	}, timeout, 1).Should(BeNil())
+	}, timeout, 1).ShouldNot(HaveOccurred())
 
 	if wantFound {
 		return obj
@@ -239,7 +239,7 @@ func ListWithTimeout(
 		}
 
 		return nil
-	}, timeout, 1).Should(BeNil())
+	}, timeout, 1).ShouldNot(HaveOccurred())
 
 	if wantFound {
 		return list
@@ -277,7 +277,7 @@ func ListWithTimeoutByNamespace(
 		}
 
 		return nil
-	}, timeout, 1).Should(BeNil())
+	}, timeout, 1).ShouldNot(HaveOccurred())
 
 	if wantFound {
 		return list


### PR DESCRIPTION
Also adjusts `KubectlWithOutput()` so that the `stderr` message is returned with the error, rather than the unhelpful "exit status 1" system error.