### PR TITLE
Remove client certificate authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8
 	k8s.io/api v0.27.7
 	k8s.io/apimachinery v0.27.7
-	k8s.io/apiserver v0.27.7
 	k8s.io/client-go v0.27.7
 	k8s.io/klog/v2 v2.100.1
 	open-cluster-management.io/api v0.12.0
@@ -31,7 +30,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -366,8 +364,6 @@ k8s.io/apiextensions-apiserver v0.27.7 h1:YqIOwZAUokzxJIjunmUd4zS1v3JhK34EPXn+pP
 k8s.io/apiextensions-apiserver v0.27.7/go.mod h1:x0p+b5a955lfPz9gaDeBy43obM12s+N9dNHK6+dUL+g=
 k8s.io/apimachinery v0.27.7 h1:Gxgtb7Y/Rsu8ymgmUEaiErkxa6RY4oTd8kNUI6SUR58=
 k8s.io/apimachinery v0.27.7/go.mod h1:jBGQgTjkw99ef6q5hv1YurDd3BqKDk9YRxmX0Ozo0i8=
-k8s.io/apiserver v0.27.7 h1:E8sDHwfUug82YC1++qvE73QxihaXDqT4tr8XYBOEtc4=
-k8s.io/apiserver v0.27.7/go.mod h1:OrLG9RwCOerutAlo8QJW5EHzUG9Dad7k6rgcDUNSO/w=
 k8s.io/client-go v0.27.7 h1:+Xgh9OOKv6A3qdD4Dnl/0VOI5EvAv+0s/OseDxVVTwQ=
 k8s.io/client-go v0.27.7/go.mod h1:dZ2kqcalYp5YZ2EV12XIMc77G6PxHWOJp/kclZr4+5Q=
 k8s.io/component-base v0.27.7 h1:kngM58HR9W9Nqpv7e4rpdRyWnKl/ABpUhLAZ+HoliMs=

--- a/main.go
+++ b/main.go
@@ -583,24 +583,8 @@ func startComplianceEventsAPI(
 	reconciler.DynamicWatcher = dbSecretDynamicWatcher
 
 	var cert *tls.Certificate
-	var clientAuthCAs []byte
 
 	if complianceAPICert != "" && complianceAPIKey != "" {
-		if cfg.CAData == nil && cfg.CAFile == "" {
-			log.Info("The kubeconfig does not contain a CA")
-			os.Exit(1)
-		}
-
-		if cfg.CAData == nil {
-			clientAuthCAs, err = os.ReadFile(cfg.CAFile)
-			if err != nil {
-				log.Error(err, "The kubeconfig does not contain a valid CA")
-				os.Exit(1)
-			}
-		} else {
-			clientAuthCAs = cfg.CAData
-		}
-
 		certTemp, err := tls.LoadX509KeyPair(complianceAPICert, complianceAPIKey)
 		if err != nil {
 			log.Error(
@@ -617,7 +601,7 @@ func startComplianceEventsAPI(
 		log.Info("The compliance events history API will listen on HTTP since no certificate was provided")
 	}
 
-	complianceAPI := complianceeventsapi.NewComplianceAPIServer(complianceAPIAddr, cfg, clientAuthCAs, cert)
+	complianceAPI := complianceeventsapi.NewComplianceAPIServer(complianceAPIAddr, cfg, cert)
 
 	wg.Add(1)
 

--- a/test/e2e/case18_compliance_api_test.go
+++ b/test/e2e/case18_compliance_api_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Test the compliance events API", Label("compliance-events-api"
 		err = complianceServerCtx.MigrateDB(ctx, k8sClient, "open-cluster-management")
 		Expect(err).ToNot(HaveOccurred())
 
-		complianceAPI := complianceeventsapi.NewComplianceAPIServer("localhost:8385", k8sConfig, nil, nil)
+		complianceAPI := complianceeventsapi.NewComplianceAPIServer("localhost:8385", k8sConfig, nil)
 
 		httpCtx, httpCtxCancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
This will not be used and it didn't work on OpenShift because the CAs included in the Kubeconfig don't include the CA that signed the client certificate. This would have required additional code to pull the correct CA.