### PR TITLE
Reset the database ID cache when applicable

### DIFF
--- a/controllers/complianceeventsapi/complianceeventsapi_controller.go
+++ b/controllers/complianceeventsapi/complianceeventsapi_controller.go
@@ -181,6 +181,11 @@ func (r *ComplianceDBSecretReconciler) Reconcile(
 		// Need the connection URL for the migration.
 		r.ComplianceServerCtx.connectionURL = r.ConnectionURL
 
+		// Clear the database ID caches in case this is a new database or the database was restored
+		r.ComplianceServerCtx.ParentPolicyToID = sync.Map{}
+		r.ComplianceServerCtx.PolicyToID = sync.Map{}
+		clusterKeyCache = sync.Map{}
+
 		if parsedConnectionURL == "" {
 			r.ComplianceServerCtx.DB = nil
 		} else {


### PR DESCRIPTION
This resets the database ID cache whenever the database connection URL changes or an invalid cache entry is found. This also combines the database ID caches on the propagator reconciler and the compliance history API goroutines.

Relates:
https://issues.redhat.com/browse/ACM-10109