### PR TITLE
Ignore role bindings in default namespace for RBAC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stolostron/go-log-utils v0.1.2
 	github.com/stolostron/go-template-utils/v4 v4.0.1-0.20231212190701-4dc096ec1b40
 	github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8
+	github.com/stolostron/rbac-api-utils v0.0.0-20240227203157-d0f039286f99
 	k8s.io/api v0.27.7
 	k8s.io/apimachinery v0.27.7
 	k8s.io/client-go v0.27.7
@@ -66,7 +67,6 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/stolostron/go-template-utils/v4 v4.0.1-0.20231212190701-4dc096ec1b40 
 github.com/stolostron/go-template-utils/v4 v4.0.1-0.20231212190701-4dc096ec1b40/go.mod h1:HtsbCTMS4oFBQpy8le4/Td1YTsHfsh1aP8uRMcquaHI=
 github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8 h1:fA4m/qD8S/l4jSyf2W/eG1iCSnokRXfkoKde4Ohy1f8=
 github.com/stolostron/kubernetes-dependency-watches v0.5.2-0.20231212185913-628ab39622b8/go.mod h1:8vRsL1GGBw0jjCwP8CH8d30NVNYKhUy0rdBSQZ2znx8=
-github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398 h1:lDYoE83J3+fekj/RstoHitheBEGKYwqjRlNhoTGq698=
-github.com/stolostron/rbac-api-utils v0.0.0-20230213163759-159deac7d398/go.mod h1:zYGYkVgY+sL501na1x5RDCKMrHD+JAwb6oRFU8e9XlU=
+github.com/stolostron/rbac-api-utils v0.0.0-20240227203157-d0f039286f99 h1:cPredF0PaBRYVadMe6+ZcvfgWct+QZMijZKWXDpwkb4=
+github.com/stolostron/rbac-api-utils v0.0.0-20240227203157-d0f039286f99/go.mod h1:zYGYkVgY+sL501na1x5RDCKMrHD+JAwb6oRFU8e9XlU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/test/resources/case18_compliance_api_test/wrong_service_account.yaml
+++ b/test/resources/case18_compliance_api_test/wrong_service_account.yaml
@@ -15,7 +15,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: wrong-cluster-role
 rules:
 - apiGroups:
@@ -33,6 +32,33 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: wrong-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: wrong-sa
+  namespace: default
+---
+# This ensures role bindings (not cluster role bindings) are ignored in the test
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: wrong-cluster-role-bound-with-role-binding
+rules:
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wrong-cluster-role-binding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: wrong-cluster-role-bound-with-role-binding
 subjects:
 - kind: ServiceAccount
   name: wrong-sa


### PR DESCRIPTION
SelfSubjectRulesReview errantly considered role bindings in the default namespace for cluster scoped access. A namespace is required for SelfSubjectRulesReview, so a completely invalid namespace is provided to avoid this. rbac-api-utils was updated to do this by default.
    
Relates:
https://issues.redhat.com/browse/ACM-10162