### PR TITLE
Generate a disabled compliance history API entry for local-cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ install-resources:
 	@echo creating namespaces
 	kubectl create ns policy-propagator-test
 	kubectl create ns $(KIND_NAMESPACE)
+	kubectl create ns local-cluster
 	kubectl create ns managed1
 	kubectl create ns managed2
 	kubectl create ns managed3
@@ -237,6 +238,7 @@ install-resources:
 	kubectl apply -k deploy/rbac -n $(KIND_NAMESPACE)
 	kubectl apply -f deploy/manager/service-account.yaml -n $(KIND_NAMESPACE)
 	@echo creating cluster resources
+	kubectl apply -f test/resources/local-cluster.yaml
 	kubectl apply -f test/resources/managed1-cluster.yaml
 	kubectl apply -f test/resources/managed2-cluster.yaml
 	kubectl apply -f test/resources/managed3-cluster.yaml

--- a/controllers/complianceeventsapi/server.go
+++ b/controllers/complianceeventsapi/server.go
@@ -118,6 +118,7 @@ func init() {
 
 const (
 	postgresForeignKeyViolationCode = "23503"
+	postgresUniqueViolationCode     = "23505"
 )
 
 var (
@@ -1022,7 +1023,7 @@ func postComplianceEvent(serverContext *ComplianceServerCtx, cfg *rest.Config, w
 		return
 	}
 
-	clusterFK, err := getClusterForeignKey(r.Context(), serverContext.DB, reqEvent.Cluster)
+	clusterFK, err := GetClusterForeignKey(r.Context(), serverContext.DB, reqEvent.Cluster)
 	if err != nil {
 		log.Error(err, "error getting cluster foreign key")
 		writeErrMsgJSON(w, "Internal Error", http.StatusInternalServerError)
@@ -1333,7 +1334,8 @@ func convertToString(v interface{}) string {
 	}
 }
 
-func getClusterForeignKey(ctx context.Context, db *sql.DB, cluster Cluster) (int32, error) {
+// GetClusterForeignKey will return the database ID based on the cluster.ClusterID.
+func GetClusterForeignKey(ctx context.Context, db *sql.DB, cluster Cluster) (int32, error) {
 	// Check cache
 	key, ok := clusterKeyCache.Load(cluster.ClusterID)
 	if ok {

--- a/controllers/complianceeventsapi/types.go
+++ b/controllers/complianceeventsapi/types.go
@@ -208,6 +208,35 @@ func (c *Cluster) GetOrCreate(ctx context.Context, db *sql.DB) error {
 	return getOrCreate(ctx, db, c)
 }
 
+// EventDetailsQueued is a slimmed down EventDetails that supports being put in a client-go work queue.
+// The client-go work queue rejects an EventDetails object because it is not hashable due to the Metadata field
+// using the JSONMap type.
+type EventDetailsQueued struct {
+	ClusterID      int32
+	PolicyID       int32
+	ParentPolicyID int32
+	Compliance     string
+	Message        string
+	Timestamp      time.Time
+	ReportedBy     string
+}
+
+func (e *EventDetailsQueued) EventDetails() *EventDetails {
+	return &EventDetails{
+		ClusterID:      e.ClusterID,
+		PolicyID:       e.PolicyID,
+		ParentPolicyID: &e.ParentPolicyID,
+		Compliance:     e.Compliance,
+		Message:        e.Message,
+		Timestamp:      e.Timestamp,
+		ReportedBy:     &e.ReportedBy,
+	}
+}
+
+func (e *EventDetailsQueued) InsertQuery() (string, []any) {
+	return e.EventDetails().InsertQuery()
+}
+
 type EventDetails struct {
 	KeyID          int32     `db:"id" json:"-"`
 	ClusterID      int32     `db:"cluster_id" json:"-"`

--- a/controllers/propagator/replicatedpolicy_controller.go
+++ b/controllers/propagator/replicatedpolicy_controller.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	templates "github.com/stolostron/go-template-utils/v4/pkg/templates"
 	k8sdepwatches "github.com/stolostron/kubernetes-dependency-watches/client"
@@ -620,13 +621,115 @@ func (r *ReplicatedPolicyReconciler) cleanUpReplicated(ctx context.Context, repl
 
 	deleteErr := r.Delete(ctx, replicatedPolicy)
 
-	version.resourceVersion = "deleted"
+	if deleteErr != nil {
+		if k8serrors.IsNotFound(deleteErr) {
+			version.resourceVersion = "deleted"
+		}
+	} else {
+		version.resourceVersion = "deleted"
 
-	if watcherErr != nil {
-		return watcherErr
+		// Normally the spec-sync controller handles this, however, if it's a self-managed hub policy, the spec-sync
+		// controller does not run. So this is a special case.
+		if replicatedPolicy.Namespace == "local-cluster" && r.ComplianceServerCtx.DB != nil {
+			r.recordDisabledEvents(ctx, replicatedPolicy)
+		}
 	}
 
-	return deleteErr
+	return errors.Join(watcherErr, deleteErr)
+}
+
+// recordDisabledEvents will generate and record disabled compliance events in the compliance history database for each
+// policy template. On retryable errors, the generated compliance event is added to the ComplianceServerCtx queue
+// for MonitorDatabaseConnection to handle once the database is back up.
+func (r *ReplicatedPolicyReconciler) recordDisabledEvents(
+	ctx context.Context, replicatedPolicy *policiesv1.Policy,
+) {
+	log := log.WithValues("policy", replicatedPolicy.Name)
+
+	if replicatedPolicy.Annotations[ParentPolicyIDAnnotation] == "" {
+		return
+	}
+
+	parentPolicyID, err := strconv.ParseInt(replicatedPolicy.Annotations[ParentPolicyIDAnnotation], 10, 32)
+	if err != nil {
+		log.Error(err, "Failed to record a disabled compliance event due to an invalid parent policy ID")
+
+		return
+	}
+
+	dbConnectionDown := false
+
+	for _, template := range replicatedPolicy.Spec.PolicyTemplates {
+		plcTmplUnstruct := &unstructured.Unstructured{}
+
+		err := plcTmplUnstruct.UnmarshalJSON(template.ObjectDefinition.Raw)
+		if err != nil {
+			continue
+		}
+
+		policyIDStr := plcTmplUnstruct.GetAnnotations()[PolicyIDAnnotation]
+		if policyIDStr == "" {
+			continue
+		}
+
+		policyID, err := strconv.ParseInt(policyIDStr, 10, 32)
+		if err != nil {
+			log.Error(err, "Failed to record a disabled compliance event due to an invalid policy ID")
+
+			continue
+		}
+
+		complianceEvent := &complianceeventsapi.EventDetailsQueued{
+			ParentPolicyID: int32(parentPolicyID),
+			PolicyID:       int32(policyID),
+			Compliance:     "Disabled",
+			Message:        "The policy was removed because the parent policy no longer applies to this cluster",
+			Timestamp:      time.Now().UTC(),
+			ReportedBy:     "governance-policy-framework",
+		}
+
+		if dbConnectionDown {
+			log.Info(
+				"Failed to record the compliance event. Will requeue.",
+				"error", complianceeventsapi.ErrDBConnectionFailed.Error(),
+				"eventMessage", complianceEvent.Message,
+				"policyID", complianceEvent.PolicyID,
+			)
+
+			r.ComplianceServerCtx.Queue.Add(complianceEvent)
+
+			continue
+		}
+
+		err = complianceeventsapi.RecordLocalClusterComplianceEvent(
+			ctx, r.ComplianceServerCtx, complianceEvent.EventDetails(),
+		)
+
+		requeue := errors.Is(err, complianceeventsapi.ErrRetryable)
+		if requeue {
+			r.ComplianceServerCtx.Queue.Add(complianceEvent)
+		}
+
+		if errors.Is(err, complianceeventsapi.ErrDBConnectionFailed) {
+			dbConnectionDown = true
+		}
+
+		if err != nil {
+			log.Info(
+				"Failed to record the compliance event",
+				"requeue", requeue,
+				"error", err.Error(),
+				"eventMessage", complianceEvent.Message,
+				"policyID", complianceEvent.PolicyID,
+			)
+		} else {
+			log.V(2).Info(
+				"Recorded the compliance event",
+				"eventMessage", complianceEvent.Message,
+				"policyID", complianceEvent.PolicyID,
+			)
+		}
+	}
 }
 
 func (r *ReplicatedPolicyReconciler) singleClusterDecision(

--- a/controllers/propagator/replicatedpolicy_controller_test.go
+++ b/controllers/propagator/replicatedpolicy_controller_test.go
@@ -24,7 +24,7 @@ func getPolicyTemplateAnnotations(policy *policiesv1.Policy, templateIndex int) 
 }
 
 func TestSetDBAnnotationsNoDB(t *testing.T) {
-	complianceAPICtx, err := complianceeventsapi.NewComplianceServerCtx("postgres://localhost?mydb")
+	complianceAPICtx, err := complianceeventsapi.NewComplianceServerCtx("postgres://localhost?mydb", "unknown")
 	if err != nil {
 		t.Fatalf("Failed create the compliance server context: %v", err)
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -53,6 +53,7 @@ var (
 	gvrNamespace          schema.GroupVersionResource
 	defaultTimeoutSeconds int
 	defaultImageRegistry  string
+	clientToken           string
 )
 
 func TestE2e(t *testing.T) {
@@ -111,6 +112,11 @@ var _ = BeforeSuite(func() {
 	defaultImageRegistry = "quay.io/open-cluster-management"
 	testNamespace = "policy-propagator-test"
 	defaultTimeoutSeconds = 30
+
+	k8sConfig, err := LoadConfig("", "", "")
+	Expect(err).ToNot(HaveOccurred())
+	clientToken = k8sConfig.BearerToken
+
 	By("Create Namespace if needed")
 	namespaces := clientHub.CoreV1().Namespaces()
 	if _, err := namespaces.Get(

--- a/test/resources/local-cluster.yaml
+++ b/test/resources/local-cluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    cloud: auto-detect
+    name: local-cluster
+    vendor: auto-detect
+  name: local-cluster
+spec: {}


### PR DESCRIPTION
The spec-sync controller is responsible for generating this event ordinarily, however, since the spec-sync does not run on self-managed hubs, it will not generate the disabled event. The Propagator must step in to do so.

The approach taken in this commit is resilient to temporary database outages.

The "Adds the database IDs by using the cache" test was removed because it was errantly reporting as passing due to it deleting the root policy and not the replicated policy as intended. There is no way to get this test to work without going to extreme lengths after 9a641148a6badf022d96e037ac3c7c4b9f726388 since it wipes the database ID cache when the secret changes. The secret was updated to something invalid to cause a database outage. Other attempts such as deleting the Service did not work because it would not interrupt the existing TCP connection with the database server. It'd only prevent new ones from occuring. Stopping the database deployment causes the database to be wiped since it does not use a persistent volume.

Relates:
https://issues.redhat.com/browse/ACM-10003