### PR TITLE
Fix chunked transfers with the CSV reports

### DIFF
--- a/test/e2e/case18_compliance_api_test.go
+++ b/test/e2e/case18_compliance_api_test.go
@@ -1773,6 +1773,7 @@ var _ = Describe("Test the compliance events API", Label("compliance-events-api"
 
 				By("Content-type should be CSV")
 				Expect(resp.Header.Get("Content-Type")).Should(Equal("text/csv"))
+				Expect(resp.TransferEncoding).Should(ContainElement("chunked"))
 
 				csvReader := csv.NewReader(resp.Body)
 


### PR DESCRIPTION
This sends a chunk every 100 lines of CSV.