### PR TITLE
Update CRD descriptions

### DIFF
--- a/api/v1/placementbinding_types.go
+++ b/api/v1/placementbinding_types.go
@@ -7,78 +7,104 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Subject defines the resource that can be used as PlacementBinding subject
+// Subject defines the resource to bind to the placement resource.
 type Subject struct {
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
+	// APIGroup is the API group to which the kind belongs. Must be set to
+	// "policy.open-cluster-management.io".
+	//
 	// +kubebuilder:validation:Enum=policy.open-cluster-management.io
-	APIGroup string `json:"apiGroup"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	APIGroup string `json:"apiGroup"`
+
+	// Kind is the kind of the object to bind to the placement resource. Must be set to either
+	// "Policy" or "PolicySet".
+	//
 	// +kubebuilder:validation:Enum=Policy;PolicySet
+	// +kubebuilder:validation:MinLength=1
 	Kind string `json:"kind"`
-	// +kubebuilder:validation:Required
+
+	// Name is the name of the policy or policy set to bind to the placement resource.
+	//
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 }
 
-// PlacementSubject defines the resource that can be used as PlacementBinding placementRef
+// PlacementSubject defines the placement resource that is being bound to the subjects defined in
+// the placement binding.
 type PlacementSubject struct {
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
+	// APIGroup is the API group to which the kind belongs. Must be set to
+	// "cluster.open-cluster-management.io" for Placement or "apps.open-cluster-management.io" for
+	// PlacementRule (deprecated).
+	//
 	// +kubebuilder:validation:Enum=apps.open-cluster-management.io;cluster.open-cluster-management.io
-	APIGroup string `json:"apiGroup"`
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
+	APIGroup string `json:"apiGroup"`
+
+	// Kind is the kind of the placement resource. Must be set to either "Placement" or
+	// "PlacementRule" (deprecated).
+	//
 	// +kubebuilder:validation:Enum=PlacementRule;Placement
+	// +kubebuilder:validation:MinLength=1
 	Kind string `json:"kind"`
-	// +kubebuilder:validation:Required
+
+	// Name is the name of the placement resource being bound.
+	//
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 }
 
-// PlacementBindingStatus defines the observed state of PlacementBinding
-type PlacementBindingStatus struct{}
-
-// BindingOverrides defines the overrides to the Subjects
+// BindingOverrides defines the overrides for the subjects.
 type BindingOverrides struct {
+	// RemediationAction overrides the policy remediationAction on target clusters. This parameter is
+	// optional. If you set it, you must set it to "enforce".
+	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=Enforce;enforce
-	// This field overrides the policy remediationAction on target clusters
 	RemediationAction string `json:"remediationAction,omitempty"`
 }
 
-// SubFilter defines the selection rule for bound clusters
+// SubFilter provides the ability to apply overrides to a subset of bound clusters when multiple
+// placement bindings are used to bind a policy to placements. When set, only the overrides will be
+// applied to the clusters bound by this placement binding but it will not be considered for placing
+// the policy. This parameter is optional. If you set it, you must set it to "restricted".
 type SubFilter string
 
-const Restricted SubFilter = "restricted"
+const (
+	Restricted SubFilter = "restricted"
+)
 
-//+kubebuilder:object:root=true
+// PlacementBindingStatus defines the observed state of the PlacementBinding resource.
+type PlacementBindingStatus struct{}
 
-// PlacementBinding is the Schema for the placementbindings API
+// PlacementBinding is the schema for the placementbindings API. A PlacementBinding resource binds a
+// managed cluster placement resource to a policy or policy set, along with configurable overrides.
+//
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=placementbindings,scope=Namespaced
 // +kubebuilder:resource:path=placementbindings,shortName=pb
 type PlacementBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	PlacementRef PlacementSubject `json:"placementRef"`
+
+	// +kubebuilder:validation:MinItems=1
+	Subjects []Subject `json:"subjects"`
+
 	// +kubebuilder:validation:Optional
 	BindingOverrides BindingOverrides `json:"bindingOverrides,omitempty"`
-	// This field provides the ability to select a subset of bound clusters
+
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Enum=restricted
 	SubFilter SubFilter `json:"subFilter,omitempty"`
-	// +kubebuilder:validation:Required
-	PlacementRef PlacementSubject `json:"placementRef"`
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinItems=1
-	Subjects []Subject              `json:"subjects"`
-	Status   PlacementBindingStatus `json:"status,omitempty"`
+
+	Status PlacementBindingStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-
-// PlacementBindingList contains a list of PlacementBinding
+// PlacementBindingList contains a list of placement bindings.
+//
+// +kubebuilder:object:root=true
 type PlacementBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1/policy_types.go
+++ b/api/v1/policy_types.go
@@ -8,43 +8,46 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
-// RemediationAction describes weather to enforce or inform
+// RemediationAction specifies the remediation of the policy. The parameter values are "enforce" and
+// "inform".
+//
 // +kubebuilder:validation:Enum=Inform;inform;Enforce;enforce
 type RemediationAction string
 
 const (
-	// Enforce is an remediationAction to make changes
 	Enforce RemediationAction = "Enforce"
-
-	// Inform is an remediationAction to only inform
-	Inform RemediationAction = "Inform"
+	Inform  RemediationAction = "Inform"
 )
 
-// PolicyTemplate template for custom security policy
+// PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster,
+// along with configurations on how it should be applied.
 type PolicyTemplate struct {
-	// +kubebuilder:pruning:PreserveUnknownFields
 	// A Kubernetes object defining the policy to apply to a managed cluster
+	//
+	// +kubebuilder:pruning:PreserveUnknownFields
 	ObjectDefinition runtime.RawExtension `json:"objectDefinition"`
 
-	// Additional PolicyDependencies that only apply to this template
+	// ExtraDependencies is additional PolicyDependencies that only apply to this policy template.
+	// ExtraDependencies is a list of dependency objects detailed with extra considerations for
+	// compliance that should be fulfilled before applying the policy template to the managed
+	// clusters.
 	ExtraDependencies []PolicyDependency `json:"extraDependencies,omitempty"`
 
-	// Ignore this template's Pending status when calculating the overall Policy status
+	// IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this
+	// template when calculating the overall policy status. The default value is "false" to not ignore a
+	// "Pending" status.
 	IgnorePending bool `json:"ignorePending,omitempty"`
 }
 
-// ComplianceState shows the state of enforcement
+// ComplianceState reports the observed status resulting from the definitions of the policy.
+//
+// +kubebuilder:validation:Enum=Compliant;Pending;NonCompliant
 type ComplianceState string
 
 const (
-	// Compliant is a ComplianceState
-	Compliant ComplianceState = "Compliant"
-
-	// NonCompliant is a ComplianceState
+	Compliant    ComplianceState = "Compliant"
 	NonCompliant ComplianceState = "NonCompliant"
-
-	// Pending is a ComplianceState
-	Pending ComplianceState = "Pending"
+	Pending      ComplianceState = "Pending"
 )
 
 // Each PolicyDependency defines an object reference which must be in a certain compliance
@@ -52,61 +55,90 @@ const (
 type PolicyDependency struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// The name of the object to be checked
+	// Name is the name of the object that the policy depends on.
 	Name string `json:"name"`
 
-	// The namespace of the object to be checked (optional)
+	// Namespace is the namespace of the object that the policy depends on (optional).
 	Namespace string `json:"namespace,omitempty"`
 
-	// The ComplianceState (at path .status.compliant) required before the policy should be created
-	// +kubebuilder:validation:Enum=Compliant;Pending;NonCompliant
+	// Compliance is the required ComplianceState of the object that the policy depends on, at the
+	// following path, .status.compliant.
 	Compliance ComplianceState `json:"compliance"`
 }
 
-// PolicySpec defines the desired state of Policy
+// PolicySpec defines the configurations of the policy engine resources to deliver to the managed
+// clusters.
 type PolicySpec struct {
-	// This provides the ability to enable and disable your policies.
+	// Disabled is a boolean parameter you can use to enable and disable the policy. When disabled,
+	// the policy is removed from managed clusters.
 	Disabled bool `json:"disabled"`
 
-	// If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
-	// If set to false, only the policy framework specific policy labels and annotations will be copied to the
-	// replicated policy.
+	// CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied
+	// when replicating the policy to a managed cluster. If set to "true", all of the labels and
+	// annotations of the policy are copied to the replicated policy. If set to "false", only the
+	// policy framework-specific policy labels and annotations are copied to the replicated policy.
+	// This setting is useful if there is tracking for metadata that should only exist on the root
+	// policy. It is recommended to set this to "false" when using Argo CD to deploy the policy
+	// definition since Argo CD uses metadata for tracking that should not be replicated. The default
+	// value is "true".
+	//
 	// +kubebuilder:validation:Optional
 	CopyPolicyMetadata *bool `json:"copyPolicyMetadata,omitempty"`
 
-	// This value (Enforce or Inform) will override the remediationAction on each template
+	// RemediationAction specifies the remediation of the policy. The parameter values are "enforce"
+	// and "inform". If specified, the value that is defined overrides any remediationAction parameter
+	// defined in the child policies in the "policy-templates" section. Important: Not all policy
+	// engine kinds support the enforce feature.
 	RemediationAction RemediationAction `json:"remediationAction,omitempty"`
 
-	// Used to create one or more policies to apply to a managed cluster
+	// PolicyTemplates is a list of definitions of policy engine resources to apply to managed
+	// clusters along with configurations on how it should be applied.
 	PolicyTemplates []*PolicyTemplate `json:"policy-templates"`
 
-	// PolicyDependencies that apply to each template in this Policy
+	// PolicyDependencies is a list of dependency objects detailed with extra considerations for
+	// compliance that should be fulfilled before applying the policies to the managed clusters.
 	Dependencies []PolicyDependency `json:"dependencies,omitempty"`
 }
 
-// PlacementDecision defines the decision made by controller
+// PlacementDecision is the cluster name returned by the placement resource.
 type PlacementDecision struct {
 	ClusterName      string `json:"clusterName,omitempty"`
 	ClusterNamespace string `json:"clusterNamespace,omitempty"`
 }
 
-// Placement defines the placement results
+// Placement reports how and what managed cluster placement resources are attached to the policy.
 type Placement struct {
-	PlacementBinding string              `json:"placementBinding,omitempty"`
-	PlacementRule    string              `json:"placementRule,omitempty"`
-	Placement        string              `json:"placement,omitempty"`
-	Decisions        []PlacementDecision `json:"decisions,omitempty"`
-	PolicySet        string              `json:"policySet,omitempty"`
+	// PlacementBinding is the name of the PlacementBinding resource, from the
+	// policies.open-cluster-management.io API group, that binds the placement resource to the policy.
+	PlacementBinding string `json:"placementBinding,omitempty"`
+
+	// PlacementRule (deprecated) is the name of the PlacementRule resource, from the
+	// apps.open-cluster-management.io API group, that is bound to the policy.
+	PlacementRule string `json:"placementRule,omitempty"`
+
+	// Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
+	// API group, that is bound to the policy.
+	Placement string `json:"placement,omitempty"`
+
+	// Decisions is the list of managed clusters returned by the placement resource for this binding.
+	Decisions []PlacementDecision `json:"decisions,omitempty"`
+
+	// PolicySet is the name of the policy set containing this policy and bound to the placement. If
+	// specified, then for this placement the policy is being propagated through this policy set
+	// rather than the policy being bound directly to a placement and propagated individually.
+	PolicySet string `json:"policySet,omitempty"`
 }
 
-// CompliancePerClusterStatus defines compliance per cluster status
+// CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for
+// this policy.
 type CompliancePerClusterStatus struct {
 	ComplianceState  ComplianceState `json:"compliant,omitempty"`
 	ClusterName      string          `json:"clustername,omitempty"`
 	ClusterNamespace string          `json:"clusternamespace,omitempty"`
 }
 
-// DetailsPerTemplate defines compliance details and history
+// DetailsPerTemplate reports the current compliance state and list of recent compliance messages
+// for a given policy template.
 type DetailsPerTemplate struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	TemplateMeta    metav1.ObjectMeta   `json:"templateMeta,omitempty"`
@@ -114,26 +146,45 @@ type DetailsPerTemplate struct {
 	History         []ComplianceHistory `json:"history,omitempty"`
 }
 
-// ComplianceHistory defines compliance details history
+// ComplianceHistory reports a compliance message from a given time and event.
 type ComplianceHistory struct {
+	// LastTimestamp is the timestamp of the event that reported the message.
 	LastTimestamp metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`
-	Message       string      `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
-	EventName     string      `json:"eventName,omitempty"`
+
+	// Message is the compliance message resulting from evaluating the policy resource.
+	Message string `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+
+	// EventName is the name of the event attached to the message.
+	EventName string `json:"eventName,omitempty"`
 }
 
-// PolicyStatus defines the observed state of Policy
+// PolicyStatus reports the observed status of the policy resulting from its policy templates.
 type PolicyStatus struct {
-	Placement []*Placement                  `json:"placement,omitempty"` // used by root policy
-	Status    []*CompliancePerClusterStatus `json:"status,omitempty"`    // used by root policy
+	// ROOT POLICY STATUS FIELDS
 
-	// +kubebuilder:validation:Enum=Compliant;Pending;NonCompliant
-	ComplianceState ComplianceState       `json:"compliant,omitempty"` // used by replicated policy
-	Details         []*DetailsPerTemplate `json:"details,omitempty"`   // used by replicated policy
+	// Placement is a list of managed cluster placement resources bound to the policy. This status
+	// field is only used in the root policy on the hub cluster.
+	Placement []*Placement `json:"placement,omitempty"`
+
+	// Status is a list of managed clusters and the current compliance state of each one. This
+	// status field is only used in the root policy on the hub cluster.
+	Status []*CompliancePerClusterStatus `json:"status,omitempty"`
+
+	// REPLICATED POLICY STATUS FIELDS
+
+	// ComplianceState reports the observed status resulting from the definitions of this policy. This
+	// status field is only used in the replicated policy in the managed cluster namespace.
+	ComplianceState ComplianceState `json:"compliant,omitempty"`
+
+	// Details is the list of compliance details for each policy template definition. This status
+	// field is only used in the replicated policy in the managed cluster namespace.
+	Details []*DetailsPerTemplate `json:"details,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-
-// Policy is the Schema for the policies API
+// Policy is the schema for the policies API. Policy wraps other policy engine resources in its
+// "policy-templates" array in order to deliver the resources to managed clusters.
+//
+// +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=policies,scope=Namespaced
 // +kubebuilder:resource:path=policies,shortName=plc
@@ -148,9 +199,9 @@ type Policy struct {
 	Status PolicyStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-
-// PolicyList contains a list of Policy
+// PolicyList contains a list of policies.
+//
+// +kubebuilder:object:root=true
 type PolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -105,13 +105,13 @@ func (in *PlacementBinding) DeepCopyInto(out *PlacementBinding) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	out.BindingOverrides = in.BindingOverrides
 	out.PlacementRef = in.PlacementRef
 	if in.Subjects != nil {
 		in, out := &in.Subjects, &out.Subjects
 		*out = make([]Subject, len(*in))
 		copy(*out, *in)
 	}
+	out.BindingOverrides = in.BindingOverrides
 	out.Status = in.Status
 }
 

--- a/api/v1beta1/policyautomation_types.go
+++ b/api/v1beta1/policyautomation_types.go
@@ -10,32 +10,12 @@ import (
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 )
 
-// PolicyAutomationSpec defines the desired state of PolicyAutomation
-type PolicyAutomationSpec struct {
-	// PolicyRef is the name of the policy that this automation resource
-	// is bound to.
-	// +kubebuilder:validation:Required
-	PolicyRef string `json:"policyRef"`
-	// Mode decides how automation is going to be triggered
-	Mode PolicyAutomationMode `json:"mode"`
-	// EventHook decides when automation is going to be triggered
-	// +kubebuilder:validation:Enum={noncompliant}
-	// +kubebuilder:validation:Required
-	EventHook string `json:"eventHook,omitempty"`
-	// RescanAfter is reserved for future use.
-	RescanAfter string `json:"rescanAfter,omitempty"`
-	// DelayAfterRunSeconds sets the minimum number of seconds before
-	// an automation can run again due to a new violation on the same
-	// managed cluster. This only applies to the EveryEvent Mode.  The
-	// default value is 0.
-	// +kubebuilder:validation:Minimum=0
-	DelayAfterRunSeconds uint `json:"delayAfterRunSeconds,omitempty"`
-	// +kubebuilder:validation:Required
-	Automation AutomationDef `json:"automationDef"`
-}
+const DefaultPolicyViolationsLimit = 1000
 
+// Mode specifies how often automation is initiated. The supported values are "once", "everyEvent",
+// and "disabled".
+//
 // +kubebuilder:validation:Enum={once,everyEvent,disabled}
-// +kubebuilder:validation:Required
 type PolicyAutomationMode string
 
 const (
@@ -44,35 +24,134 @@ const (
 	Disabled   PolicyAutomationMode = "disabled"
 )
 
-const DefaultPolicyViolationsLimit = 1000
-
-// AutomationDef defines the automation to invoke
+// AutomationDef defines the automation to invoke.
 type AutomationDef struct {
 	// Type of the automation to invoke
 	Type string `json:"type,omitempty"`
-	// Name of the Ansible Template to run in Tower as a job
-	// +kubebuilder:validation:Required
+
+	// Name of the Ansible Template to run in Ansible Automation Platform as a job.
+	//
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
+
 	// ExtraVars is passed to the Ansible job at execution time and is a known Ansible entity.
+	//
 	// +kubebuilder:pruning:PreserveUnknownFields
 	ExtraVars *runtime.RawExtension `json:"extra_vars,omitempty"`
-	// TowerSecret is the name of the secret that contains the Ansible Automation Platform
-	// credential.
-	// +kubebuilder:validation:Required
+
+	// TowerSecret is the name of the secret that contains the Ansible Automation Platform credential.
+	//
 	// +kubebuilder:validation:MinLength=1
 	TowerSecret string `json:"secret"`
-	// JobTTL sets the time to live for the Kubernetes AnsibleJob object after the Ansible job run has finished.
+
+	// JobTTL sets the time to live for the Kubernetes AnsibleJob object after the Ansible job run has
+	// finished.
 	JobTTL *int `json:"jobTtl,omitempty"`
+
+	// The maximum number of violating cluster contexts that are provided to the Ansible job as
+	// extra variables. When policyViolationsLimit is set to "0", it means no limit. The default value
+	// is "1000".
+	//
 	// +kubebuilder:validation:Minimum=0
-	// The maximum number of violating cluster contexts that will be provided to the Ansible job as extra variables.
-	// When policyViolationsLimit is set to 0, it means no limit.
-	// The default value is 1000.
 	PolicyViolationsLimit *uint `json:"policyViolationsLimit,omitempty"`
 }
 
-// ViolationContext defines the non-compliant replicated policy information
-// that is sent to the AnsibleJob through extra_vars.
+// PolicyAutomationSpec defines how and when automation is initiated for the referenced policy.
+type PolicyAutomationSpec struct {
+	Automation AutomationDef        `json:"automationDef"`
+	Mode       PolicyAutomationMode `json:"mode"`
+
+	// PolicyRef is the name of the policy that this automation resource is bound to.
+	PolicyRef string `json:"policyRef"`
+
+	// EventHook specifies the compliance state that initiates automation. This must be set to
+	// "noncompliant".
+	//
+	// +kubebuilder:validation:Enum={noncompliant}
+	// +kubebuilder:validation:Required
+	EventHook string `json:"eventHook,omitempty"`
+
+	// RescanAfter is reserved for future use and should not be set.
+	RescanAfter string `json:"rescanAfter,omitempty"`
+
+	// DelayAfterRunSeconds sets the minimum number of seconds before an automation can run again due
+	// to a new violation on the same managed cluster. This only applies to the EveryEvent mode. The
+	// default value is "0".
+	//
+	// +kubebuilder:validation:Minimum=0
+	DelayAfterRunSeconds uint `json:"delayAfterRunSeconds,omitempty"`
+}
+
+// ClusterEvent shows the PolicyAutomation event on each target cluster.
+type ClusterEvent struct {
+	// AutomationStartTime is the policy automation start time for everyEvent mode.
+	AutomationStartTime string `json:"automationStartTime"`
+
+	// EventTime is the last policy compliance transition event time.
+	EventTime string `json:"eventTime"`
+}
+
+// PolicyAutomationStatus defines the observed state of the PolicyAutomation resource.
+type PolicyAutomationStatus struct {
+	// Cluster name as the key of ClustersWithEvent
+	ClustersWithEvent map[string]ClusterEvent `json:"clustersWithEvent,omitempty"`
+}
+
+// PolicyAutomation is the schema for the policyautomations API. PolicyAutomation configures
+// creation of an AnsibleJob, from the tower.ansible.com API group, to initiate Ansible to run upon
+// noncompliant events of the attached policy, or when you manually initiate the run with the
+// "policy.open-cluster-management.io/rerun=true" annotation.
+//
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=policyautomations,scope=Namespaced
+// +kubebuilder:resource:path=policyautomations,shortName=plca
+type PolicyAutomation struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   PolicyAutomationSpec   `json:"spec"`
+	Status PolicyAutomationStatus `json:"status,omitempty"`
+}
+
+// PolicyAutomationList contains a list of policy automations.
+//
+// +kubebuilder:object:root=true
+type PolicyAutomationList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []PolicyAutomation `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&PolicyAutomation{}, &PolicyAutomationList{})
+}
+
+////////////////////////////////////////////////
+// Context sent to AnsibleJobs via extra_vars //
+////////////////////////////////////////////////
+
+// ReplicatedComplianceHistory defines the replicated policy compliance details history.
+type ReplicatedComplianceHistory struct {
+	LastTimestamp metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`
+	Message       string      `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
+}
+
+// ReplicatedDetailsPerTemplate defines the replicated policy compliance details and history.
+type ReplicatedDetailsPerTemplate struct {
+	ComplianceState policyv1.ComplianceState      `json:"compliant"`
+	History         []ReplicatedComplianceHistory `json:"history"`
+}
+
+// ReplicatedPolicyStatus defines the replicated policy status.
+type ReplicatedPolicyStatus struct {
+	ComplianceState  policyv1.ComplianceState       `json:"compliant"`         // used by replicated policy
+	ViolationMessage string                         `json:"violation_message"` // used by replicated policy
+	Details          []ReplicatedDetailsPerTemplate `json:"details"`           // used by replicated policy
+}
+
+// ViolationContext defines the noncompliant replicated policy information that is sent to the
+// AnsibleJob through the extra_vars parameter.
 type ViolationContext struct {
 	TargetClusters   []string                          `json:"targetClusters" ansibleJob:"target_clusters"`
 	PolicyName       string                            `json:"policyName" ansibleJob:"policy_name"`
@@ -80,64 +159,4 @@ type ViolationContext struct {
 	HubCluster       string                            `json:"hubCluster" ansibleJob:"hub_cluster"`
 	PolicySets       []string                          `json:"policySets" ansibleJob:"policy_sets"`
 	PolicyViolations map[string]ReplicatedPolicyStatus `json:"policyViolations" ansibleJob:"policy_violations"`
-}
-
-// PolicyAutomationStatus defines the observed state of PolicyAutomation
-type PolicyAutomationStatus struct {
-	// Cluster name as the key of ClustersWithEvent
-	ClustersWithEvent map[string]ClusterEvent `json:"clustersWithEvent,omitempty"`
-}
-
-//+kubebuilder:object:root=true
-
-// PolicyAutomation is the Schema for the policyautomations API
-// +kubebuilder:subresource:status
-// +kubebuilder:resource:path=policyautomations,scope=Namespaced
-// +kubebuilder:resource:path=policyautomations,shortName=plca
-type PolicyAutomation struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:Required
-	Spec   PolicyAutomationSpec   `json:"spec"`
-	Status PolicyAutomationStatus `json:"status,omitempty"`
-}
-
-//+kubebuilder:object:root=true
-
-// PolicyAutomationList contains a list of PolicyAutomation
-type PolicyAutomationList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []PolicyAutomation `json:"items"`
-}
-
-// PolicyAutomation events on each target cluster
-type ClusterEvent struct {
-	// Policy automation start time for everyEvent mode
-	AutomationStartTime string `json:"automationStartTime"`
-	// The last policy compliance transition event time
-	EventTime string `json:"eventTime"`
-}
-
-func init() {
-	SchemeBuilder.Register(&PolicyAutomation{}, &PolicyAutomationList{})
-}
-
-// ReplicatedDetailsPerTemplate defines the replicated policy compliance details and history
-type ReplicatedDetailsPerTemplate struct {
-	ComplianceState policyv1.ComplianceState      `json:"compliant"`
-	History         []ReplicatedComplianceHistory `json:"history"`
-}
-
-// ReplicatedComplianceHistory defines the replicated policy compliance details history
-type ReplicatedComplianceHistory struct {
-	LastTimestamp metav1.Time `json:"lastTimestamp,omitempty" protobuf:"bytes,7,opt,name=lastTimestamp"`
-	Message       string      `json:"message,omitempty" protobuf:"bytes,4,opt,name=message"`
-}
-
-// ReplicatedPolicyStatus defines the replicated policy status
-type ReplicatedPolicyStatus struct {
-	ComplianceState  policyv1.ComplianceState       `json:"compliant"`         // used by replicated policy
-	ViolationMessage string                         `json:"violation_message"` // used by replicated policy
-	Details          []ReplicatedDetailsPerTemplate `json:"details"`           // used by replicated policy
 }

--- a/api/v1beta1/policyset_types.go
+++ b/api/v1beta1/policyset_types.go
@@ -5,56 +5,71 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
 
-// A custom type is required since there is no way to have a kubebuilder marker
-// apply to the items of a slice.
+	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+)
 
 // +kubebuilder:validation:MinLength=1
 type NonEmptyString string
 
-// PolicySetSpec describes a group of policies that are related and
-// can be placed on the same managed clusters.
+// PolicySetSpec defines the group of policies to be included in the policy set.
 type PolicySetSpec struct {
-	// Description of this PolicySet.
+	// Description is the description of this policy set.
 	Description string `json:"description,omitempty"`
-	// Policies that are grouped together within the PolicySet.
-	// +kubebuilder:validation:Required
+
+	// Policies is a list of policy names that are contained within the policy set.
 	Policies []NonEmptyString `json:"policies"`
 }
 
-// PolicySetStatus defines the observed state of PolicySet
-type PolicySetStatus struct {
-	Placement     []PolicySetStatusPlacement `json:"placement,omitempty"`
-	Compliant     string                     `json:"compliant,omitempty"`
-	StatusMessage string                     `json:"statusMessage,omitempty"`
-}
-
-// PolicySetStatusPlacement defines a placement object for the status
+// PolicySetStatusPlacement reports how and what managed cluster placement resources are attached to
+// the policy set.
 type PolicySetStatusPlacement struct {
+	// PlacementBinding is the name of the PlacementBinding resource, from the
+	// policies.open-cluster-management.io API group, that binds the placement resource to the policy
+	// set.
 	PlacementBinding string `json:"placementBinding,omitempty"`
-	Placement        string `json:"placement,omitempty"`
-	PlacementRule    string `json:"placementRule,omitempty"`
+
+	// Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
+	// API group, that is bound to the policy.
+	Placement string `json:"placement,omitempty"`
+
+	// PlacementRule (deprecated) is the name of the PlacementRule resource, from the
+	// apps.open-cluster-management.io API group, that is bound to the policy.
+	PlacementRule string `json:"placementRule,omitempty"`
 }
 
+// PolicySetStatus reports the observed status of the policy set resulting from its policies.
+type PolicySetStatus struct {
+	Placement []PolicySetStatusPlacement `json:"placement,omitempty"`
+
+	// Compliant reports the observed status resulting from the compliance of the policies within.
+	Compliant policyv1.ComplianceState `json:"compliant,omitempty"`
+
+	// StatusMessge reports the current state while determining the compliance of the policy set.
+	StatusMessage string `json:"statusMessage,omitempty"`
+}
+
+// PolicySet is the schema for the policysets API. A policy set is a logical grouping of policies
+// from the same namespace. The policy set is bound to a placement resource and applies the
+// placement to all policies within the set. The status reports the overall compliance of the set.
+//
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=policysets,scope=Namespaced
 // +kubebuilder:resource:path=policysets,shortName=plcset
 // +kubebuilder:printcolumn:name="Compliance state",type="string",JSONPath=".status.compliant"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// PolicySet is the Schema for the policysets API
 type PolicySet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:Required
+
 	Spec   PolicySetSpec   `json:"spec"`
 	Status PolicySetStatus `json:"status,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-
-// PolicySetList contains a list of PolicySet
+// PolicySetList contains a list of policy sets.
+//
+// +kubebuilder:object:root=true
 type PolicySetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/controllers/policyset/policyset_controller.go
+++ b/controllers/policyset/policyset_controller.go
@@ -238,7 +238,7 @@ func (r *PolicySetReconciler) processPolicySet(ctx context.Context, plcSet *poli
 		StatusMessage: getStatusMessage(disabledPolicies, unknownPolicies, deletedPolicies, pendingPolicies),
 	}
 	if showCompliance(compliancesFound, unknownPolicies, pendingPolicies) {
-		builtStatus.Compliant = string(aggregatedCompliance)
+		builtStatus.Compliant = aggregatedCompliance
 	}
 
 	if !equality.Semantic.DeepEqual(plcSet.Status, builtStatus) {

--- a/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/kustomize/policy.open-cluster-management.io_policies.yaml
@@ -29,7 +29,9 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Policy is the Schema for the policies API
+        description: |-
+          Policy is the schema for the policies API. Policy wraps other policy engine resources in its
+          "policy-templates" array in order to deliver the resources to managed clusters.
         properties:
           apiVersion:
             description: |-
@@ -49,17 +51,25 @@ spec:
           metadata:
             type: object
           spec:
-            description: PolicySpec defines the desired state of Policy
+            description: |-
+              PolicySpec defines the configurations of the policy engine resources to deliver to the managed
+              clusters.
             properties:
               copyPolicyMetadata:
                 description: |-
-                  If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
-                  If set to false, only the policy framework specific policy labels and annotations will be copied to the
-                  replicated policy.
+                  CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied
+                  when replicating the policy to a managed cluster. If set to "true", all of the labels and
+                  annotations of the policy are copied to the replicated policy. If set to "false", only the
+                  policy framework-specific policy labels and annotations are copied to the replicated policy.
+                  This setting is useful if there is tracking for metadata that should only exist on the root
+                  policy. It is recommended to set this to "false" when using Argo CD to deploy the policy
+                  definition since Argo CD uses metadata for tracking that should not be replicated. The default
+                  value is "true".
                 type: boolean
               dependencies:
-                description: PolicyDependencies that apply to each template in this
-                  Policy
+                description: |-
+                  PolicyDependencies is a list of dependency objects detailed with extra considerations for
+                  compliance that should be fulfilled before applying the policies to the managed clusters.
                 items:
                   description: |-
                     Each PolicyDependency defines an object reference which must be in a certain compliance
@@ -73,8 +83,9 @@ spec:
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                       type: string
                     compliance:
-                      description: The ComplianceState (at path .status.compliant)
-                        required before the policy should be created
+                      description: |-
+                        Compliance is the required ComplianceState of the object that the policy depends on, at the
+                        following path, .status.compliant.
                       enum:
                       - Compliant
                       - Pending
@@ -89,10 +100,12 @@ spec:
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: The name of the object to be checked
+                      description: Name is the name of the object that the policy
+                        depends on.
                       type: string
                     namespace:
-                      description: The namespace of the object to be checked (optional)
+                      description: Namespace is the namespace of the object that the
+                        policy depends on (optional).
                       type: string
                   required:
                   - compliance
@@ -100,18 +113,25 @@ spec:
                   type: object
                 type: array
               disabled:
-                description: This provides the ability to enable and disable your
-                  policies.
+                description: |-
+                  Disabled is a boolean parameter you can use to enable and disable the policy. When disabled,
+                  the policy is removed from managed clusters.
                 type: boolean
               policy-templates:
-                description: Used to create one or more policies to apply to a managed
-                  cluster
+                description: |-
+                  PolicyTemplates is a list of definitions of policy engine resources to apply to managed
+                  clusters along with configurations on how it should be applied.
                 items:
-                  description: PolicyTemplate template for custom security policy
+                  description: |-
+                    PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster,
+                    along with configurations on how it should be applied.
                   properties:
                     extraDependencies:
-                      description: Additional PolicyDependencies that only apply to
-                        this template
+                      description: |-
+                        ExtraDependencies is additional PolicyDependencies that only apply to this policy template.
+                        ExtraDependencies is a list of dependency objects detailed with extra considerations for
+                        compliance that should be fulfilled before applying the policy template to the managed
+                        clusters.
                       items:
                         description: |-
                           Each PolicyDependency defines an object reference which must be in a certain compliance
@@ -125,8 +145,9 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                             type: string
                           compliance:
-                            description: The ComplianceState (at path .status.compliant)
-                              required before the policy should be created
+                            description: |-
+                              Compliance is the required ComplianceState of the object that the policy depends on, at the
+                              following path, .status.compliant.
                             enum:
                             - Compliant
                             - Pending
@@ -141,11 +162,12 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: The name of the object to be checked
+                            description: Name is the name of the object that the policy
+                              depends on.
                             type: string
                           namespace:
-                            description: The namespace of the object to be checked
-                              (optional)
+                            description: Namespace is the namespace of the object
+                              that the policy depends on (optional).
                             type: string
                         required:
                         - compliance
@@ -153,8 +175,10 @@ spec:
                         type: object
                       type: array
                     ignorePending:
-                      description: Ignore this template's Pending status when calculating
-                        the overall Policy status
+                      description: |-
+                        IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this
+                        template when calculating the overall policy status. The default value is "false" to not ignore a
+                        "Pending" status.
                       type: boolean
                     objectDefinition:
                       description: A Kubernetes object defining the policy to apply
@@ -166,8 +190,11 @@ spec:
                   type: object
                 type: array
               remediationAction:
-                description: This value (Enforce or Inform) will override the remediationAction
-                  on each template
+                description: |-
+                  RemediationAction specifies the remediation of the policy. The parameter values are "enforce"
+                  and "inform". If specified, the value that is defined overrides any remediationAction parameter
+                  defined in the child policies in the "policy-templates" section. Important: Not all policy
+                  engine kinds support the enforce feature.
                 enum:
                 - Inform
                 - inform
@@ -179,33 +206,52 @@ spec:
             - policy-templates
             type: object
           status:
-            description: PolicyStatus defines the observed state of Policy
+            description: PolicyStatus reports the observed status of the policy resulting
+              from its policy templates.
             properties:
               compliant:
-                description: ComplianceState shows the state of enforcement
+                description: |-
+                  ComplianceState reports the observed status resulting from the definitions of this policy. This
+                  status field is only used in the replicated policy in the managed cluster namespace.
                 enum:
                 - Compliant
                 - Pending
                 - NonCompliant
                 type: string
               details:
+                description: |-
+                  Details is the list of compliance details for each policy template definition. This status
+                  field is only used in the replicated policy in the managed cluster namespace.
                 items:
-                  description: DetailsPerTemplate defines compliance details and history
+                  description: |-
+                    DetailsPerTemplate reports the current compliance state and list of recent compliance messages
+                    for a given policy template.
                   properties:
                     compliant:
-                      description: ComplianceState shows the state of enforcement
+                      description: ComplianceState reports the observed status resulting
+                        from the definitions of the policy.
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                     history:
                       items:
-                        description: ComplianceHistory defines compliance details
-                          history
+                        description: ComplianceHistory reports a compliance message
+                          from a given time and event.
                         properties:
                           eventName:
+                            description: EventName is the name of the event attached
+                              to the message.
                             type: string
                           lastTimestamp:
+                            description: LastTimestamp is the timestamp of the event
+                              that reported the message.
                             format: date-time
                             type: string
                           message:
+                            description: Message is the compliance message resulting
+                              from evaluating the policy resource.
                             type: string
                         type: object
                       type: array
@@ -215,13 +261,19 @@ spec:
                   type: object
                 type: array
               placement:
+                description: |-
+                  Placement is a list of managed cluster placement resources bound to the policy. This status
+                  field is only used in the root policy on the hub cluster.
                 items:
-                  description: Placement defines the placement results
+                  description: Placement reports how and what managed cluster placement
+                    resources are attached to the policy.
                   properties:
                     decisions:
+                      description: Decisions is the list of managed clusters returned
+                        by the placement resource for this binding.
                       items:
-                        description: PlacementDecision defines the decision made by
-                          controller
+                        description: PlacementDecision is the cluster name returned
+                          by the placement resource.
                         properties:
                           clusterName:
                             type: string
@@ -230,26 +282,48 @@ spec:
                         type: object
                       type: array
                     placement:
+                      description: |-
+                        Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
+                        API group, that is bound to the policy.
                       type: string
                     placementBinding:
+                      description: |-
+                        PlacementBinding is the name of the PlacementBinding resource, from the
+                        policies.open-cluster-management.io API group, that binds the placement resource to the policy.
                       type: string
                     placementRule:
+                      description: |-
+                        PlacementRule (deprecated) is the name of the PlacementRule resource, from the
+                        apps.open-cluster-management.io API group, that is bound to the policy.
                       type: string
                     policySet:
+                      description: |-
+                        PolicySet is the name of the policy set containing this policy and bound to the placement. If
+                        specified, then for this placement the policy is being propagated through this policy set
+                        rather than the policy being bound directly to a placement and propagated individually.
                       type: string
                   type: object
                 type: array
               status:
+                description: |-
+                  Status is a list of managed clusters and the current compliance state of each one. This
+                  status field is only used in the root policy on the hub cluster.
                 items:
-                  description: CompliancePerClusterStatus defines compliance per cluster
-                    status
+                  description: |-
+                    CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for
+                    this policy.
                   properties:
                     clustername:
                       type: string
                     clusternamespace:
                       type: string
                     compliant:
-                      description: ComplianceState shows the state of enforcement
+                      description: ComplianceState reports the observed status resulting
+                        from the definitions of the policy.
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                   type: object
                 type: array

--- a/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_placementbindings.yaml
@@ -19,7 +19,9 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: PlacementBinding is the Schema for the placementbindings API
+        description: |-
+          PlacementBinding is the schema for the placementbindings API. A PlacementBinding resource binds a
+          managed cluster placement resource to a policy or policy set, along with configurable overrides.
         properties:
           apiVersion:
             description: |-
@@ -29,11 +31,12 @@ spec:
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           bindingOverrides:
-            description: BindingOverrides defines the overrides to the Subjects
+            description: BindingOverrides defines the overrides for the subjects.
             properties:
               remediationAction:
-                description: This field overrides the policy remediationAction on
-                  target clusters
+                description: |-
+                  RemediationAction overrides the policy remediationAction on target clusters. This parameter is
+                  optional. If you set it, you must set it to "enforce".
                 enum:
                 - Enforce
                 - enforce
@@ -50,22 +53,31 @@ spec:
           metadata:
             type: object
           placementRef:
-            description: PlacementSubject defines the resource that can be used as
-              PlacementBinding placementRef
+            description: |-
+              PlacementSubject defines the placement resource that is being bound to the subjects defined in
+              the placement binding.
             properties:
               apiGroup:
+                description: |-
+                  APIGroup is the API group to which the kind belongs. Must be set to
+                  "cluster.open-cluster-management.io" for Placement or "apps.open-cluster-management.io" for
+                  PlacementRule (deprecated).
                 enum:
                 - apps.open-cluster-management.io
                 - cluster.open-cluster-management.io
                 minLength: 1
                 type: string
               kind:
+                description: |-
+                  Kind is the kind of the placement resource. Must be set to either "Placement" or
+                  "PlacementRule" (deprecated).
                 enum:
                 - PlacementRule
                 - Placement
                 minLength: 1
                 type: string
               name:
+                description: Name is the name of the placement resource being bound.
                 minLength: 1
                 type: string
             required:
@@ -74,31 +86,42 @@ spec:
             - name
             type: object
           status:
-            description: PlacementBindingStatus defines the observed state of PlacementBinding
+            description: PlacementBindingStatus defines the observed state of the
+              PlacementBinding resource.
             type: object
           subFilter:
-            description: This field provides the ability to select a subset of bound
-              clusters
+            description: |-
+              SubFilter provides the ability to apply overrides to a subset of bound clusters when multiple
+              placement bindings are used to bind a policy to placements. When set, only the overrides will be
+              applied to the clusters bound by this placement binding but it will not be considered for placing
+              the policy. This parameter is optional. If you set it, you must set it to "restricted".
             enum:
             - restricted
             type: string
           subjects:
             items:
-              description: Subject defines the resource that can be used as PlacementBinding
-                subject
+              description: Subject defines the resource to bind to the placement resource.
               properties:
                 apiGroup:
+                  description: |-
+                    APIGroup is the API group to which the kind belongs. Must be set to
+                    "policy.open-cluster-management.io".
                   enum:
                   - policy.open-cluster-management.io
                   minLength: 1
                   type: string
                 kind:
+                  description: |-
+                    Kind is the kind of the object to bind to the placement resource. Must be set to either
+                    "Policy" or "PolicySet".
                   enum:
                   - Policy
                   - PolicySet
                   minLength: 1
                   type: string
                 name:
+                  description: Name is the name of the policy or policy set to bind
+                    to the placement resource.
                   minLength: 1
                   type: string
               required:

--- a/deploy/crds/policy.open-cluster-management.io_policies.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policies.yaml
@@ -29,7 +29,9 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Policy is the Schema for the policies API
+        description: |-
+          Policy is the schema for the policies API. Policy wraps other policy engine resources in its
+          "policy-templates" array in order to deliver the resources to managed clusters.
         properties:
           apiVersion:
             description: |-
@@ -49,17 +51,25 @@ spec:
           metadata:
             type: object
           spec:
-            description: PolicySpec defines the desired state of Policy
+            description: |-
+              PolicySpec defines the configurations of the policy engine resources to deliver to the managed
+              clusters.
             properties:
               copyPolicyMetadata:
                 description: |-
-                  If set to true (default), all the policy's labels and annotations will be copied to the replicated policy.
-                  If set to false, only the policy framework specific policy labels and annotations will be copied to the
-                  replicated policy.
+                  CopyPolicyMetadata specifies whether the labels and annotations of a policy should be copied
+                  when replicating the policy to a managed cluster. If set to "true", all of the labels and
+                  annotations of the policy are copied to the replicated policy. If set to "false", only the
+                  policy framework-specific policy labels and annotations are copied to the replicated policy.
+                  This setting is useful if there is tracking for metadata that should only exist on the root
+                  policy. It is recommended to set this to "false" when using Argo CD to deploy the policy
+                  definition since Argo CD uses metadata for tracking that should not be replicated. The default
+                  value is "true".
                 type: boolean
               dependencies:
-                description: PolicyDependencies that apply to each template in this
-                  Policy
+                description: |-
+                  PolicyDependencies is a list of dependency objects detailed with extra considerations for
+                  compliance that should be fulfilled before applying the policies to the managed clusters.
                 items:
                   description: |-
                     Each PolicyDependency defines an object reference which must be in a certain compliance
@@ -86,8 +96,9 @@ spec:
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                       type: string
                     compliance:
-                      description: The ComplianceState (at path .status.compliant)
-                        required before the policy should be created
+                      description: |-
+                        Compliance is the required ComplianceState of the object that the policy depends on, at the
+                        following path, .status.compliant.
                       enum:
                       - Compliant
                       - Pending
@@ -102,10 +113,12 @@ spec:
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description: The name of the object to be checked
+                      description: Name is the name of the object that the policy
+                        depends on.
                       type: string
                     namespace:
-                      description: The namespace of the object to be checked (optional)
+                      description: Namespace is the namespace of the object that the
+                        policy depends on (optional).
                       type: string
                   required:
                   - compliance
@@ -113,18 +126,25 @@ spec:
                   type: object
                 type: array
               disabled:
-                description: This provides the ability to enable and disable your
-                  policies.
+                description: |-
+                  Disabled is a boolean parameter you can use to enable and disable the policy. When disabled,
+                  the policy is removed from managed clusters.
                 type: boolean
               policy-templates:
-                description: Used to create one or more policies to apply to a managed
-                  cluster
+                description: |-
+                  PolicyTemplates is a list of definitions of policy engine resources to apply to managed
+                  clusters along with configurations on how it should be applied.
                 items:
-                  description: PolicyTemplate template for custom security policy
+                  description: |-
+                    PolicyTemplate is the definition of the policy engine resource to apply to the managed cluster,
+                    along with configurations on how it should be applied.
                   properties:
                     extraDependencies:
-                      description: Additional PolicyDependencies that only apply to
-                        this template
+                      description: |-
+                        ExtraDependencies is additional PolicyDependencies that only apply to this policy template.
+                        ExtraDependencies is a list of dependency objects detailed with extra considerations for
+                        compliance that should be fulfilled before applying the policy template to the managed
+                        clusters.
                       items:
                         description: |-
                           Each PolicyDependency defines an object reference which must be in a certain compliance
@@ -151,8 +171,9 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                             type: string
                           compliance:
-                            description: The ComplianceState (at path .status.compliant)
-                              required before the policy should be created
+                            description: |-
+                              Compliance is the required ComplianceState of the object that the policy depends on, at the
+                              following path, .status.compliant.
                             enum:
                             - Compliant
                             - Pending
@@ -167,11 +188,12 @@ spec:
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                             type: string
                           name:
-                            description: The name of the object to be checked
+                            description: Name is the name of the object that the policy
+                              depends on.
                             type: string
                           namespace:
-                            description: The namespace of the object to be checked
-                              (optional)
+                            description: Namespace is the namespace of the object
+                              that the policy depends on (optional).
                             type: string
                         required:
                         - compliance
@@ -179,8 +201,10 @@ spec:
                         type: object
                       type: array
                     ignorePending:
-                      description: Ignore this template's Pending status when calculating
-                        the overall Policy status
+                      description: |-
+                        IgnorePending is a boolean parameter to specify whether to ignore the "Pending" status of this
+                        template when calculating the overall policy status. The default value is "false" to not ignore a
+                        "Pending" status.
                       type: boolean
                     objectDefinition:
                       description: A Kubernetes object defining the policy to apply
@@ -192,8 +216,11 @@ spec:
                   type: object
                 type: array
               remediationAction:
-                description: This value (Enforce or Inform) will override the remediationAction
-                  on each template
+                description: |-
+                  RemediationAction specifies the remediation of the policy. The parameter values are "enforce"
+                  and "inform". If specified, the value that is defined overrides any remediationAction parameter
+                  defined in the child policies in the "policy-templates" section. Important: Not all policy
+                  engine kinds support the enforce feature.
                 enum:
                 - Inform
                 - inform
@@ -205,33 +232,52 @@ spec:
             - policy-templates
             type: object
           status:
-            description: PolicyStatus defines the observed state of Policy
+            description: PolicyStatus reports the observed status of the policy resulting
+              from its policy templates.
             properties:
               compliant:
-                description: ComplianceState shows the state of enforcement
+                description: |-
+                  ComplianceState reports the observed status resulting from the definitions of this policy. This
+                  status field is only used in the replicated policy in the managed cluster namespace.
                 enum:
                 - Compliant
                 - Pending
                 - NonCompliant
                 type: string
               details:
+                description: |-
+                  Details is the list of compliance details for each policy template definition. This status
+                  field is only used in the replicated policy in the managed cluster namespace.
                 items:
-                  description: DetailsPerTemplate defines compliance details and history
+                  description: |-
+                    DetailsPerTemplate reports the current compliance state and list of recent compliance messages
+                    for a given policy template.
                   properties:
                     compliant:
-                      description: ComplianceState shows the state of enforcement
+                      description: ComplianceState reports the observed status resulting
+                        from the definitions of the policy.
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                     history:
                       items:
-                        description: ComplianceHistory defines compliance details
-                          history
+                        description: ComplianceHistory reports a compliance message
+                          from a given time and event.
                         properties:
                           eventName:
+                            description: EventName is the name of the event attached
+                              to the message.
                             type: string
                           lastTimestamp:
+                            description: LastTimestamp is the timestamp of the event
+                              that reported the message.
                             format: date-time
                             type: string
                           message:
+                            description: Message is the compliance message resulting
+                              from evaluating the policy resource.
                             type: string
                         type: object
                       type: array
@@ -241,13 +287,19 @@ spec:
                   type: object
                 type: array
               placement:
+                description: |-
+                  Placement is a list of managed cluster placement resources bound to the policy. This status
+                  field is only used in the root policy on the hub cluster.
                 items:
-                  description: Placement defines the placement results
+                  description: Placement reports how and what managed cluster placement
+                    resources are attached to the policy.
                   properties:
                     decisions:
+                      description: Decisions is the list of managed clusters returned
+                        by the placement resource for this binding.
                       items:
-                        description: PlacementDecision defines the decision made by
-                          controller
+                        description: PlacementDecision is the cluster name returned
+                          by the placement resource.
                         properties:
                           clusterName:
                             type: string
@@ -256,26 +308,48 @@ spec:
                         type: object
                       type: array
                     placement:
+                      description: |-
+                        Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
+                        API group, that is bound to the policy.
                       type: string
                     placementBinding:
+                      description: |-
+                        PlacementBinding is the name of the PlacementBinding resource, from the
+                        policies.open-cluster-management.io API group, that binds the placement resource to the policy.
                       type: string
                     placementRule:
+                      description: |-
+                        PlacementRule (deprecated) is the name of the PlacementRule resource, from the
+                        apps.open-cluster-management.io API group, that is bound to the policy.
                       type: string
                     policySet:
+                      description: |-
+                        PolicySet is the name of the policy set containing this policy and bound to the placement. If
+                        specified, then for this placement the policy is being propagated through this policy set
+                        rather than the policy being bound directly to a placement and propagated individually.
                       type: string
                   type: object
                 type: array
               status:
+                description: |-
+                  Status is a list of managed clusters and the current compliance state of each one. This
+                  status field is only used in the root policy on the hub cluster.
                 items:
-                  description: CompliancePerClusterStatus defines compliance per cluster
-                    status
+                  description: |-
+                    CompliancePerClusterStatus reports the name of a managed cluster and its compliance state for
+                    this policy.
                   properties:
                     clustername:
                       type: string
                     clusternamespace:
                       type: string
                     compliant:
-                      description: ComplianceState shows the state of enforcement
+                      description: ComplianceState reports the observed status resulting
+                        from the definitions of the policy.
+                      enum:
+                      - Compliant
+                      - Pending
+                      - NonCompliant
                       type: string
                   type: object
                 type: array

--- a/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policyautomations.yaml
@@ -19,7 +19,11 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: PolicyAutomation is the Schema for the policyautomations API
+        description: |-
+          PolicyAutomation is the schema for the policyautomations API. PolicyAutomation configures
+          creation of an AnsibleJob, from the tower.ansible.com API group, to initiate Ansible to run upon
+          noncompliant events of the attached policy, or when you manually initiate the run with the
+          "policy.open-cluster-management.io/rerun=true" annotation.
         properties:
           apiVersion:
             description: |-
@@ -39,10 +43,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: PolicyAutomationSpec defines the desired state of PolicyAutomation
+            description: PolicyAutomationSpec defines how and when automation is initiated
+              for the referenced policy.
             properties:
               automationDef:
-                description: AutomationDef defines the automation to invoke
+                description: AutomationDef defines the automation to invoke.
                 properties:
                   extra_vars:
                     description: ExtraVars is passed to the Ansible job at execution
@@ -50,25 +55,25 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   jobTtl:
-                    description: JobTTL sets the time to live for the Kubernetes AnsibleJob
-                      object after the Ansible job run has finished.
+                    description: |-
+                      JobTTL sets the time to live for the Kubernetes AnsibleJob object after the Ansible job run has
+                      finished.
                     type: integer
                   name:
-                    description: Name of the Ansible Template to run in Tower as a
-                      job
+                    description: Name of the Ansible Template to run in Ansible Automation
+                      Platform as a job.
                     minLength: 1
                     type: string
                   policyViolationsLimit:
                     description: |-
-                      The maximum number of violating cluster contexts that will be provided to the Ansible job as extra variables.
-                      When policyViolationsLimit is set to 0, it means no limit.
-                      The default value is 1000.
+                      The maximum number of violating cluster contexts that are provided to the Ansible job as
+                      extra variables. When policyViolationsLimit is set to "0", it means no limit. The default value
+                      is "1000".
                     minimum: 0
                     type: integer
                   secret:
-                    description: |-
-                      TowerSecret is the name of the secret that contains the Ansible Automation Platform
-                      credential.
+                    description: TowerSecret is the name of the secret that contains
+                      the Ansible Automation Platform credential.
                     minLength: 1
                     type: string
                   type:
@@ -80,31 +85,34 @@ spec:
                 type: object
               delayAfterRunSeconds:
                 description: |-
-                  DelayAfterRunSeconds sets the minimum number of seconds before
-                  an automation can run again due to a new violation on the same
-                  managed cluster. This only applies to the EveryEvent Mode.  The
-                  default value is 0.
+                  DelayAfterRunSeconds sets the minimum number of seconds before an automation can run again due
+                  to a new violation on the same managed cluster. This only applies to the EveryEvent mode. The
+                  default value is "0".
                 minimum: 0
                 type: integer
               eventHook:
-                description: EventHook decides when automation is going to be triggered
+                description: |-
+                  EventHook specifies the compliance state that initiates automation. This must be set to
+                  "noncompliant".
                 enum:
                 - noncompliant
                 type: string
               mode:
-                description: Mode decides how automation is going to be triggered
+                description: |-
+                  Mode specifies how often automation is initiated. The supported values are "once", "everyEvent",
+                  and "disabled".
                 enum:
                 - once
                 - everyEvent
                 - disabled
                 type: string
               policyRef:
-                description: |-
-                  PolicyRef is the name of the policy that this automation resource
-                  is bound to.
+                description: PolicyRef is the name of the policy that this automation
+                  resource is bound to.
                 type: string
               rescanAfter:
-                description: RescanAfter is reserved for future use.
+                description: RescanAfter is reserved for future use and should not
+                  be set.
                 type: string
             required:
             - automationDef
@@ -112,17 +120,21 @@ spec:
             - policyRef
             type: object
           status:
-            description: PolicyAutomationStatus defines the observed state of PolicyAutomation
+            description: PolicyAutomationStatus defines the observed state of the
+              PolicyAutomation resource.
             properties:
               clustersWithEvent:
                 additionalProperties:
-                  description: PolicyAutomation events on each target cluster
+                  description: ClusterEvent shows the PolicyAutomation event on each
+                    target cluster.
                   properties:
                     automationStartTime:
-                      description: Policy automation start time for everyEvent mode
+                      description: AutomationStartTime is the policy automation start
+                        time for everyEvent mode.
                       type: string
                     eventTime:
-                      description: The last policy compliance transition event time
+                      description: EventTime is the last policy compliance transition
+                        event time.
                       type: string
                   required:
                   - automationStartTime

--- a/deploy/crds/policy.open-cluster-management.io_policysets.yaml
+++ b/deploy/crds/policy.open-cluster-management.io_policysets.yaml
@@ -26,7 +26,10 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: PolicySet is the Schema for the policysets API
+        description: |-
+          PolicySet is the schema for the policysets API. A policy set is a logical grouping of policies
+          from the same namespace. The policy set is bound to a placement resource and applies the
+          placement to all policies within the set. The status reports the overall compliance of the set.
         properties:
           apiVersion:
             description: |-
@@ -46,15 +49,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              PolicySetSpec describes a group of policies that are related and
-              can be placed on the same managed clusters.
+            description: PolicySetSpec defines the group of policies to be included
+              in the policy set.
             properties:
               description:
-                description: Description of this PolicySet.
+                description: Description is the description of this policy set.
                 type: string
               policies:
-                description: Policies that are grouped together within the PolicySet.
+                description: Policies is a list of policy names that are contained
+                  within the policy set.
                 items:
                   minLength: 1
                   type: string
@@ -63,24 +66,44 @@ spec:
             - policies
             type: object
           status:
-            description: PolicySetStatus defines the observed state of PolicySet
+            description: PolicySetStatus reports the observed status of the policy
+              set resulting from its policies.
             properties:
               compliant:
+                description: Compliant reports the observed status resulting from
+                  the compliance of the policies within.
+                enum:
+                - Compliant
+                - Pending
+                - NonCompliant
                 type: string
               placement:
                 items:
-                  description: PolicySetStatusPlacement defines a placement object
-                    for the status
+                  description: |-
+                    PolicySetStatusPlacement reports how and what managed cluster placement resources are attached to
+                    the policy set.
                   properties:
                     placement:
+                      description: |-
+                        Placement is the name of the Placement resource, from the cluster.open-cluster-management.io
+                        API group, that is bound to the policy.
                       type: string
                     placementBinding:
+                      description: |-
+                        PlacementBinding is the name of the PlacementBinding resource, from the
+                        policies.open-cluster-management.io API group, that binds the placement resource to the policy
+                        set.
                       type: string
                     placementRule:
+                      description: |-
+                        PlacementRule (deprecated) is the name of the PlacementRule resource, from the
+                        apps.open-cluster-management.io API group, that is bound to the policy.
                       type: string
                   type: object
                 type: array
               statusMessage:
+                description: StatusMessge reports the current state while determining
+                  the compliance of the policy set.
                 type: string
             type: object
         required:


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-8992

I came up with my own linting rules as I went, mainly separating the descriptions from the kubebuilder tags with an empty comment line and also structuring the structs so that the "parent" structs are at the bottom of the file. I also discovered a lack of `omitempty` actually makes the field required, so the "required" tags aren't actually necessary unless `omitempty` is present, which is why those are removed but the CRD didn't change.

I also mashed the changes into a single commit because there wasn't really a great way to tease the changes apart. A review is probably easier by opening up the individual file (particularly the resulting CRD YAML) rather than looking at the changes made.

/cc @dockerymick @mprahl @gparvin @yiraeChristineKim 