### PR TITLE
Remove the code to generate disabled compliance events for local-cluster

### DIFF
--- a/controllers/complianceeventsapi/server.go
+++ b/controllers/complianceeventsapi/server.go
@@ -118,7 +118,6 @@ func init() {
 
 const (
 	postgresForeignKeyViolationCode = "23503"
-	postgresUniqueViolationCode     = "23505"
 )
 
 var (

--- a/controllers/complianceeventsapi/types.go
+++ b/controllers/complianceeventsapi/types.go
@@ -210,35 +210,6 @@ func (c *Cluster) GetOrCreate(ctx context.Context, db *sql.DB) error {
 	return getOrCreate(ctx, db, c)
 }
 
-// EventDetailsQueued is a slimmed down EventDetails that supports being put in a client-go work queue.
-// The client-go work queue rejects an EventDetails object because it is not hashable due to the Metadata field
-// using the JSONMap type.
-type EventDetailsQueued struct {
-	ClusterID      int32
-	PolicyID       int32
-	ParentPolicyID int32
-	Compliance     string
-	Message        string
-	Timestamp      time.Time
-	ReportedBy     string
-}
-
-func (e *EventDetailsQueued) EventDetails() *EventDetails {
-	return &EventDetails{
-		ClusterID:      e.ClusterID,
-		PolicyID:       e.PolicyID,
-		ParentPolicyID: &e.ParentPolicyID,
-		Compliance:     e.Compliance,
-		Message:        e.Message,
-		Timestamp:      e.Timestamp,
-		ReportedBy:     &e.ReportedBy,
-	}
-}
-
-func (e *EventDetailsQueued) InsertQuery() (string, []any) {
-	return e.EventDetails().InsertQuery()
-}
-
 type EventDetails struct {
 	KeyID          int32     `db:"id" json:"-"`
 	ClusterID      int32     `db:"cluster_id" json:"-"`


### PR DESCRIPTION
This is now handled in the governance-policy-framework-addon: https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/132

Relates:
https://issues.redhat.com/browse/ACM-10418