### PR TITLE
Retry template processing when k8s dep watcher is stopping a watch

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -367,7 +367,8 @@ func (r *ReplicatedPolicyReconciler) processTemplates(
 				k8serrors.IsInternalError(tplErr) ||
 				k8serrors.IsServiceUnavailable(tplErr) ||
 				k8serrors.IsTimeout(tplErr) ||
-				k8serrors.IsTooManyRequests(tplErr) {
+				k8serrors.IsTooManyRequests(tplErr) ||
+				errors.Is(tplErr, k8sdepwatches.ErrWatchStopping) {
 				tplErr = fmt.Errorf("%w%w", ErrRetryable, tplErr)
 			}
 


### PR DESCRIPTION
This happened in a PR CI failure where the watch was stopped and started again quickly before the watch was fully stopped.

https://github.com/stolostron/governance-policy-propagator/actions/runs/9764716738/job/26953706058?pr=773