### PR TITLE
Add the PolicyMetadata hub template variable

### DIFF
--- a/controllers/propagator/propagation.go
+++ b/controllers/propagator/propagation.go
@@ -159,6 +159,7 @@ func (r *RootPolicyReconciler) handleRootPolicy(ctx context.Context, instance *p
 type templateCtx struct {
 	ManagedClusterName   string
 	ManagedClusterLabels map[string]string
+	PolicyMetadata       map[string]interface{}
 }
 
 func addManagedClusterLabels(clusterName string) func(templates.CachingQueryAPI, interface{}) (interface{}, error) {
@@ -321,7 +322,15 @@ func (r *ReplicatedPolicyReconciler) processTemplates(
 
 		log.V(1).Info("Resolving templates on the policy template")
 
-		templateContext := templateCtx{ManagedClusterName: clusterName}
+		templateContext := templateCtx{
+			ManagedClusterName: clusterName,
+			PolicyMetadata: map[string]interface{}{
+				"annotations": rootPlc.Annotations,
+				"labels":      rootPlc.Labels,
+				"name":        rootPlc.Name,
+				"namespace":   rootPlc.Namespace,
+			},
+		}
 
 		if strings.Contains(string(policyT.ObjectDefinition.Raw), "ManagedClusterLabels") {
 			templateResolverOptions.ContextTransformers = append(

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stolostron/go-log-utils v0.1.2
-	github.com/stolostron/go-template-utils/v6 v6.0.0
+	github.com/stolostron/go-template-utils/v6 v6.1.0
 	github.com/stolostron/kubernetes-dependency-watches v0.9.0
 	github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256
 	k8s.io/api v0.29.5

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ai
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stolostron/go-log-utils v0.1.2 h1:7l1aJWvBqU2+DUyimcslT5SJpdygVY/clRDmX5sO29c=
 github.com/stolostron/go-log-utils v0.1.2/go.mod h1:8zrB8UJmp1rXhv3Ck9bBl5SpNfKk3SApeElbo96YRtQ=
-github.com/stolostron/go-template-utils/v6 v6.0.0 h1:rJ8c+1uUdNWNhulccyqEuSPnuXSVBbF9Vea0bYV2SZg=
-github.com/stolostron/go-template-utils/v6 v6.0.0/go.mod h1:zf62ttS3TSKfIhk5MXksJx7dmVNwPheH+pesYxjCw8c=
+github.com/stolostron/go-template-utils/v6 v6.1.0 h1:+ExYotoV3o1D4WlTiCaYCRhVaeEDGZPw3hMattXXylg=
+github.com/stolostron/go-template-utils/v6 v6.1.0/go.mod h1:zf62ttS3TSKfIhk5MXksJx7dmVNwPheH+pesYxjCw8c=
 github.com/stolostron/kubernetes-dependency-watches v0.9.0 h1:ZOJDdpJ9vmD8RPoHKhyZNqgv6pvasUKT18F0xSwiY1g=
 github.com/stolostron/kubernetes-dependency-watches v0.9.0/go.mod h1:BpDgquBjEbNM9dQYlLndGBX+FoaXDUJQ6eR3j1NA+Kk=
 github.com/stolostron/rbac-api-utils v0.0.0-20240404212618-7f57fc664256 h1:BeTUZoAkKzPKSH0sG4a9PaakKHuJ0h9Cks9joBn3Ns8=

--- a/test/resources/case9_templates/case9-test-policy.yaml
+++ b/test/resources/case9_templates/case9-test-policy.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: case9-test-policy
+  labels:
+    team: panthers
 spec:
   remediationAction: inform
   disabled: false
@@ -38,6 +40,8 @@ spec:
                     {{hub .ManagedClusterLabels.vendor hub}}
                   label-vendor-test-two: |
                     {{hub (lookup "cluster.open-cluster-management.io/v1" "ManagedCluster" "" .ManagedClusterName).metadata.labels.vendor hub}}
+                  root-policy-label: '{{hub .PolicyMetadata.labels.team hub}}'
+                  root-policy-namespace: '{{hub .PolicyMetadata.namespace hub}}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/test/resources/case9_templates/case9-test-replpolicy-managed1-relabelled.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed1-relabelled.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: case9-test-policy
+  labels:
+    team: panthers
 spec:
   remediationAction: inform
   disabled: false
@@ -40,3 +42,5 @@ spec:
                     Fake
                   label-vendor-test-two: |
                     Fake
+                  root-policy-label: panthers
+                  root-policy-namespace: policy-propagator-test

--- a/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed1.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: case9-test-policy
+  labels:
+    team: panthers
 spec:
   remediationAction: inform
   disabled: false
@@ -40,3 +42,5 @@ spec:
                     auto-detect
                   label-vendor-test-two: |
                     auto-detect
+                  root-policy-label: panthers
+                  root-policy-namespace: policy-propagator-test

--- a/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
+++ b/test/resources/case9_templates/case9-test-replpolicy-managed2.yaml
@@ -2,6 +2,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: case9-test-policy
+  labels:
+    team: panthers
 spec:
   remediationAction: inform
   disabled: false
@@ -40,3 +42,5 @@ spec:
                     auto-detect
                   label-vendor-test-two: |
                     auto-detect
+                  root-policy-label: panthers
+                  root-policy-namespace: policy-propagator-test


### PR DESCRIPTION
This is a subset of the root policy metadata. Specifically, it contains, name, namespace, labels, and annotations.

Relates:
https://issues.redhat.com/browse/ACM-12566