### PR TITLE
Fix dependency logic considering dots in names

### DIFF
--- a/controllers/propagator/replication.go
+++ b/controllers/propagator/replication.go
@@ -182,20 +182,21 @@ func (r *Propagator) canonicalizeDependencies(
 				})
 			}
 		} else if depIsPolicy(dep) {
-			split := strings.Split(dep.Name, ".")
-			if len(split) == 2 { // assume it's already in the correct <namespace>.<name> format
-				deps = append(deps, dep)
-			} else {
-				if dep.Namespace == "" {
-					// use the namespace from the dependent policy when otherwise not provided
-					dep.Namespace = defaultNamespace
+			if dep.Namespace == "" {
+				split := strings.Split(dep.Name, ".")
+				if len(split) >= 2 { // assume the name is already in the correct <namespace>.<name> format
+					deps = append(deps, dep)
+
+					continue
 				}
-
-				dep.Name = dep.Namespace + "." + dep.Name
-				dep.Namespace = ""
-
-				deps = append(deps, dep)
+				// use the namespace from the dependent policy when otherwise not provided
+				dep.Namespace = defaultNamespace
 			}
+
+			dep.Name = dep.Namespace + "." + dep.Name
+			dep.Namespace = ""
+
+			deps = append(deps, dep)
 		} else {
 			deps = append(deps, dep)
 		}

--- a/controllers/propagator/replication_test.go
+++ b/controllers/propagator/replication_test.go
@@ -185,10 +185,14 @@ func TestCanonicalizeDependencies(t *testing.T) {
 			input: []policiesv1.PolicyDependency{
 				depPol("red", "colors", "Compliant"),
 				depPol("blue", "colors", "NonCompliant"),
+				depPol("1.2", "colors", "NonCompliant"),
+				depPol("colors.1.2", "", "NonCompliant"),
 			},
 			want: []policiesv1.PolicyDependency{
 				depPol("colors.red", "", "Compliant"),
 				depPol("colors.blue", "", "NonCompliant"),
+				depPol("colors.1.2", "", "NonCompliant"),
+				depPol("colors.1.2", "", "NonCompliant"),
 			},
 		},
 		"policies without namespaces": {
@@ -225,7 +229,7 @@ func TestCanonicalizeDependencies(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(test.want, got) {
-				t.Fatalf("expected: %v, got: %v", test.want, got)
+				t.Fatalf("%s\nexpected:\n%v\ngot:\n%v", name, test.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
There was an assumption a dot in a name meant it contained the namespace. But this doesn't make sense if the namespace is also provided.

ref: https://issues.redhat.com/browse/ACM-14241