### PR TITLE
Fix usage of deprecated webhook.Validator interface

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        go-version: stable
 
     - name: Download Unit Coverage Result
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Replace usage of deprecated `webhook.Validator` interface with `admission.CustomValidator`.