### PR TITLE
chore: gather coverage on push

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -187,7 +187,6 @@ jobs:
         working-directory: '.'
     runs-on: ubuntu-latest
     name: Test Coverage Verification
-    if: ${{ github.event_name == 'pull_request' }}
     needs: [unit-tests, kind-tests, policyautomation-tests]
 
     steps:


### PR DESCRIPTION
Looks like this was an artifact of our home-grown coverage verification. Now that we have CodeCov, it probably makes sense to not restrict coverage gathering.

Followup to:
- #305 