### PR TITLE
fix: update permissions

### DIFF
--- a/controllers/propagator/metric.go
+++ b/controllers/propagator/metric.go
@@ -8,7 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
-//+kubebuilder:rbac:groups=authorization.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 var (
 	hubTemplateActiveWatchesMetric = prometheus.NewGauge(

--- a/controllers/propagator/rootpolicy_setup.go
+++ b/controllers/propagator/rootpolicy_setup.go
@@ -26,6 +26,7 @@ import (
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters;placementdecisions;placements,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts/token,verbs=create
 //+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -83,9 +83,15 @@ rules:
   - list
   - watch
 - apiGroups:
-  - authorization.k8s.io
+  - authentication.k8s.io
   resources:
   - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
   verbs:
   - create
 - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,6 +23,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:
@@ -34,18 +35,6 @@ kind: ClusterRole
 metadata:
   name: governance-policy-propagator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resourceNames:
@@ -64,6 +53,19 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - '*'
   resources:

--- a/deploy/rbac/leader_election_role.yaml
+++ b/deploy/rbac/leader_election_role.yaml
@@ -18,6 +18,7 @@ rules:
   - delete
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -52,9 +52,15 @@ rules:
   - list
   - watch
 - apiGroups:
-  - authorization.k8s.io
+  - authentication.k8s.io
   resources:
   - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
   verbs:
   - create
 - apiGroups:

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -6,18 +6,6 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
   resourceNames:
   - policy-encryption-key
   resources:
@@ -34,6 +22,19 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - '*'
   resources:


### PR DESCRIPTION
Followup to:
- #228 
- #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded Kubernetes RBAC permissions for handling events to cover both the core API group (`""`) and `events.k8s.io`.
  * Updated operator, role, and leader-election RBAC so the same event actions remain available (get/list/watch, create, update/patch, and delete).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->