### PR TITLE
Fix PlacementBinding deletion not triggering policy reconciliation

### DIFF
--- a/controllers/propagator/replicatepolicy_pb_eventHandler.go
+++ b/controllers/propagator/replicatepolicy_pb_eventHandler.go
@@ -3,7 +3,9 @@ package propagator
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -75,7 +77,18 @@ func (e *handlerForBinding) Update(ctx context.Context,
 func (e *handlerForBinding) Delete(ctx context.Context,
 	evt event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request],
 ) {
-	e.mapAndEnqueue(ctx, q, evt.Object)
+	pBinding := evt.Object.(*policiesv1.PlacementBinding)
+
+	if !common.IsForPolicyOrPolicySet(pBinding) {
+		return
+	}
+
+	// Reconcile across all clusters since the referenced Placement may also be deleted.
+	reqs := e.getAllReplicatedPoliciesForBinding(ctx, pBinding)
+
+	for _, req := range reqs {
+		q.Add(req)
+	}
 }
 
 // Generic implements EventHandler.
@@ -104,4 +117,29 @@ func (e *handlerForBinding) getMappedReplicatedPolicy(ctx context.Context,
 	}
 
 	return common.GetRepPoliciesInPlacementBinding(ctx, e.c, pBinding)
+}
+
+func (e *handlerForBinding) getAllReplicatedPoliciesForBinding(
+	ctx context.Context, pBinding *policiesv1.PlacementBinding,
+) []reconcile.Request {
+	rootPolicyRequest := common.GetPoliciesInPlacementBinding(ctx, e.c, pBinding)
+
+	clusterList := &clusterv1.ManagedClusterList{}
+	if err := e.c.List(ctx, clusterList); err != nil {
+		log.Error(err, "Failed to list managed clusters for deleted binding")
+		return nil
+	}
+
+	result := make([]reconcile.Request, 0, len(rootPolicyRequest)*len(clusterList.Items))
+
+	for _, rp := range rootPolicyRequest {
+		for _, cluster := range clusterList.Items {
+			result = append(result, reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      rp.Namespace + "." + rp.Name,
+				Namespace: cluster.Name,
+			}})
+		}
+	}
+
+	return result
 }

--- a/controllers/propagator/replicatepolicy_pb_eventHandler.go
+++ b/controllers/propagator/replicatepolicy_pb_eventHandler.go
@@ -126,8 +126,9 @@ func (e *handlerForBinding) getAllReplicatedPoliciesForBinding(
 
 	clusterList := &clusterv1.ManagedClusterList{}
 	if err := e.c.List(ctx, clusterList); err != nil {
-		log.Error(err, "Failed to list managed clusters for deleted binding")
-		return nil
+		log.Error(err, "Failed to list managed clusters for deleted binding, falling back to placement decisions")
+		// Fallback to using placement decisions if available
+		return common.GetRepPoliciesInPlacementBinding(ctx, e.c, pBinding)
 	}
 
 	result := make([]reconcile.Request, 0, len(rootPolicyRequest)*len(clusterList.Items))


### PR DESCRIPTION
  When a PlacementBinding with bindingOverrides is deleted along with its
  referenced Placement, the replicated policy was not being reconciled,
  causing it to remain in the override state instead of
  reverting to the root policy state.

  Root cause: The delete handler called GetDecisions() which returns empty
  when the Placement is also deleted, preventing any reconciliation.

  Fix: Modified the delete handler to reconcile across all managed clusters
  instead of relying on placement decisions. The reconciler will determine
  the correct state based on remaining bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup handling when placement bindings are deleted.
  - Ensures replicated policies are reconciled across all managed clusters, including when the referenced placement has already been removed.
  - Ignores unrelated placement binding deletions to avoid unnecessary reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->